### PR TITLE
fix: security hardening and code quality improvements

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const DATA_DIR = process.env.WCC_DATA_DIR || join(homedir(), '.wechat-claude-code');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { createInterface } from 'node:readline';
 import process from 'node:process';
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 
@@ -16,6 +16,7 @@ import { routeCommand, type CommandContext, type CommandResult } from './command
 import { claudeQuery, type QueryOptions } from './claude/provider.js';
 import { loadConfig, saveConfig } from './config.js';
 import { logger } from './logger.js';
+import { DATA_DIR } from './constants.js';
 import { MessageType, type WeixinMessage } from './wechat/types.js';
 
 // ---------------------------------------------------------------------------
@@ -60,7 +61,6 @@ function promptUser(question: string, defaultValue?: string): Promise<string> {
 // ---------------------------------------------------------------------------
 
 async function runSetup(): Promise<void> {
-  const DATA_DIR = join(process.env.HOME!, '.wechat-claude-code');
   mkdirSync(DATA_DIR, { recursive: true });
   const QR_PATH = join(DATA_DIR, 'qrcode.png');
 
@@ -76,7 +76,7 @@ async function runSetup(): Promise<void> {
     writeFileSync(QR_PATH, pngData);
 
     // Open with system default viewer (Preview.app on macOS)
-    execSync(`open "${QR_PATH}"`);
+    spawnSync('open', [QR_PATH]);
     console.log('已打开二维码图片，请用微信扫描：');
     console.log(`图片路径: ${QR_PATH}\n`);
     console.log('等待扫码绑定...');
@@ -126,7 +126,9 @@ async function runDaemon(): Promise<void> {
   const permissionBroker = createPermissionBroker(async () => {
     try {
       await sender.sendText(account.userId ?? '', sharedCtx.lastContextToken, '⏰ 权限请求超时，已自动拒绝。');
-    } catch {}
+    } catch (err) {
+      logger.warn('Failed to send permission timeout message', { error: err instanceof Error ? err.message : String(err) });
+    }
   });
 
   // -- Wire the monitor callbacks --
@@ -382,7 +384,7 @@ async function sendToClaude(
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
     logger.error('Error in sendToClaude', { error: errorMsg });
-    await sender.sendText(fromUserId, contextToken, `⚠️ 处理消息时出错: ${errorMsg}`);
+    await sender.sendText(fromUserId, contextToken, '❌ 处理出错，请稍后重试');
 
     // Reset state
     session.state = 'idle';

--- a/src/permission.ts
+++ b/src/permission.ts
@@ -9,6 +9,15 @@ export function createPermissionBroker(onTimeout?: OnPermissionTimeout) {
   const pending = new Map<string, PendingPermission>();
 
   function createPending(accountId: string, toolName: string, toolInput: string): Promise<boolean> {
+    // Clear any existing pending permission for this account to prevent timer leak
+    const existing = pending.get(accountId);
+    if (existing) {
+      clearTimeout(existing.timer);
+      pending.delete(accountId);
+      existing.resolve(false);
+      logger.warn('Replaced existing pending permission', { accountId, toolName: existing.toolName });
+    }
+
     return new Promise<boolean>((resolve) => {
       const timer = setTimeout(() => {
         logger.warn('Permission timeout, auto-denied', { accountId, toolName });

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,8 +1,7 @@
 import { loadJson, saveJson } from './store.js';
 import { join } from 'path';
 import { mkdirSync } from 'fs';
-
-const DATA_DIR = process.env.WCC_DATA_DIR || join(process.env.HOME!, '.wechat-claude-code');
+import { DATA_DIR } from './constants.js';
 const SESSIONS_DIR = join(DATA_DIR, 'sessions');
 
 export type SessionState = 'idle' | 'processing' | 'waiting_permission';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { logger } from "./logger.js";
 
 /**
  * Load a JSON file, returning a typed object or the fallback if the file
@@ -9,7 +10,11 @@ export function loadJson<T>(filePath: string, fallback: T): T {
   try {
     const raw = readFileSync(filePath, "utf-8");
     return JSON.parse(raw) as T;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      logger.warn('loadJson failed, using fallback', { filePath, error: err instanceof Error ? err.message : String(err) });
+    }
     return fallback;
   }
 }

--- a/src/tests/permission.test.ts
+++ b/src/tests/permission.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createPermissionBroker } from '../permission.js';
+
+describe('createPermissionBroker', () => {
+  it('resolves true when allowed', async () => {
+    const broker = createPermissionBroker();
+    const promise = broker.createPending('acc1', 'shell', 'ls');
+    broker.resolvePermission('acc1', true);
+    assert.strictEqual(await promise, true);
+  });
+
+  it('resolves false when denied', async () => {
+    const broker = createPermissionBroker();
+    const promise = broker.createPending('acc1', 'shell', 'rm -rf');
+    broker.resolvePermission('acc1', false);
+    assert.strictEqual(await promise, false);
+  });
+
+  it('returns false when resolving non-existent pending', () => {
+    const broker = createPermissionBroker();
+    assert.strictEqual(broker.resolvePermission('no-such', true), false);
+  });
+
+  it('getPending returns the pending permission', () => {
+    const broker = createPermissionBroker();
+    broker.createPending('acc1', 'write_file', '/tmp/x');
+    const perm = broker.getPending('acc1');
+    assert.ok(perm);
+    assert.strictEqual(perm.toolName, 'write_file');
+    assert.strictEqual(perm.toolInput, '/tmp/x');
+    // Clean up
+    broker.resolvePermission('acc1', false);
+  });
+
+  it('clears old pending when creating new one (timer leak fix)', async () => {
+    const broker = createPermissionBroker();
+    const oldPromise = broker.createPending('acc1', 'tool_a', 'input_a');
+    // Creating a second pending for the same account should resolve the old one as false
+    const newPromise = broker.createPending('acc1', 'tool_b', 'input_b');
+
+    // Old promise should have been auto-rejected
+    assert.strictEqual(await oldPromise, false);
+
+    // New pending should be for tool_b
+    const perm = broker.getPending('acc1');
+    assert.ok(perm);
+    assert.strictEqual(perm.toolName, 'tool_b');
+
+    // Clean up
+    broker.resolvePermission('acc1', true);
+    assert.strictEqual(await newPromise, true);
+  });
+
+  it('rejectPending rejects and cleans up', async () => {
+    const broker = createPermissionBroker();
+    const promise = broker.createPending('acc1', 'shell', 'ls');
+    assert.strictEqual(broker.rejectPending('acc1'), true);
+    assert.strictEqual(await promise, false);
+    assert.strictEqual(broker.getPending('acc1'), undefined);
+  });
+
+  it('formatPendingMessage includes tool info', () => {
+    const broker = createPermissionBroker();
+    broker.createPending('acc1', 'execute_shell', 'cat /etc/hosts');
+    const perm = broker.getPending('acc1')!;
+    const msg = broker.formatPendingMessage(perm);
+    assert.ok(msg.includes('execute_shell'));
+    assert.ok(msg.includes('cat /etc/hosts'));
+    assert.ok(msg.includes('y'));
+    assert.ok(msg.includes('n'));
+    // Clean up
+    broker.resolvePermission('acc1', false);
+  });
+});

--- a/src/tests/redact.test.ts
+++ b/src/tests/redact.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { redact } from '../logger.js';
+
+describe('redact — log sanitization', () => {
+  it('masks Bearer tokens', () => {
+    const input = 'Authorization: Bearer sk-abc123-secret-token';
+    const result = redact(input);
+    assert.ok(!result.includes('sk-abc123'), 'token should be masked');
+    assert.ok(result.includes('Bearer ***'));
+  });
+
+  it('masks token fields in JSON', () => {
+    const obj = { bot_token: 'secret-value-123', name: 'bot' };
+    const result = redact(obj);
+    assert.ok(!result.includes('secret-value-123'), 'token value should be masked');
+    assert.ok(result.includes('"bot"'), 'non-sensitive values should remain');
+  });
+
+  it('masks password fields', () => {
+    const obj = { password: 'hunter2' };
+    const result = redact(obj);
+    assert.ok(!result.includes('hunter2'));
+  });
+
+  it('masks api_key fields', () => {
+    const obj = { api_key: 'key-12345' };
+    const result = redact(obj);
+    assert.ok(!result.includes('key-12345'));
+  });
+
+  it('masks secret fields', () => {
+    const obj = { secret: 'very-secret' };
+    const result = redact(obj);
+    assert.ok(!result.includes('very-secret'));
+  });
+
+  it('preserves non-sensitive data', () => {
+    const obj = { status: 'ok', count: 42 };
+    const result = redact(obj);
+    assert.ok(result.includes('"ok"'));
+    assert.ok(result.includes('42'));
+  });
+
+  it('handles string input', () => {
+    const result = redact('Bearer my-token-here in header');
+    assert.ok(!result.includes('my-token-here'));
+    assert.ok(result.includes('Bearer ***'));
+  });
+
+  it('handles null/undefined gracefully', () => {
+    assert.strictEqual(redact(null), 'null');
+    assert.strictEqual(redact(undefined), undefined);
+  });
+});

--- a/src/tests/security.test.ts
+++ b/src/tests/security.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// 1. accountId path traversal validation
+// ---------------------------------------------------------------------------
+
+// Re-implement the validation logic here since the original is not exported
+function validateAccountId(accountId: string): void {
+  if (!/^[a-zA-Z0-9_-]+$/.test(accountId)) {
+    throw new Error(`Invalid accountId: "${accountId}"`);
+  }
+}
+
+describe('validateAccountId — path traversal prevention', () => {
+  it('accepts normal alphanumeric IDs', () => {
+    assert.doesNotThrow(() => validateAccountId('bot-123'));
+    assert.doesNotThrow(() => validateAccountId('abc_DEF_456'));
+    assert.doesNotThrow(() => validateAccountId('simple'));
+  });
+
+  it('rejects path traversal patterns', () => {
+    assert.throws(() => validateAccountId('../../../etc/passwd'), /Invalid accountId/);
+    assert.throws(() => validateAccountId('..'), /Invalid accountId/);
+    assert.throws(() => validateAccountId('foo/../bar'), /Invalid accountId/);
+  });
+
+  it('rejects slashes', () => {
+    assert.throws(() => validateAccountId('foo/bar'), /Invalid accountId/);
+    assert.throws(() => validateAccountId('/etc/passwd'), /Invalid accountId/);
+  });
+
+  it('rejects empty string', () => {
+    assert.throws(() => validateAccountId(''), /Invalid accountId/);
+  });
+
+  it('rejects special characters', () => {
+    assert.throws(() => validateAccountId('id with spaces'), /Invalid accountId/);
+    assert.throws(() => validateAccountId('id;rm -rf'), /Invalid accountId/);
+    assert.throws(() => validateAccountId('id\x00null'), /Invalid accountId/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. baseUrl SSRF domain whitelist
+// ---------------------------------------------------------------------------
+
+function validateBaseUrl(baseUrl: string): void {
+  if (
+    !baseUrl.startsWith('https://') ||
+    !/(?:^|\.)(?:weixin\.qq\.com|wechat\.com)(\/|$)/.test(baseUrl.slice('https://'.length))
+  ) {
+    throw new Error(`Untrusted baseUrl: "${baseUrl}"`);
+  }
+}
+
+describe('baseUrl SSRF whitelist', () => {
+  it('accepts valid weixin.qq.com URLs', () => {
+    assert.doesNotThrow(() => validateBaseUrl('https://weixin.qq.com'));
+    assert.doesNotThrow(() => validateBaseUrl('https://ilinkai.weixin.qq.com'));
+    assert.doesNotThrow(() => validateBaseUrl('https://sub.weixin.qq.com/'));
+  });
+
+  it('accepts valid wechat.com URLs', () => {
+    assert.doesNotThrow(() => validateBaseUrl('https://wechat.com'));
+    assert.doesNotThrow(() => validateBaseUrl('https://api.wechat.com'));
+  });
+
+  it('rejects non-https', () => {
+    assert.throws(() => validateBaseUrl('http://weixin.qq.com'), /Untrusted baseUrl/);
+  });
+
+  it('rejects untrusted domains', () => {
+    assert.throws(() => validateBaseUrl('https://evil.com'), /Untrusted baseUrl/);
+    assert.throws(() => validateBaseUrl('https://evil.com?x=weixin.qq.com'), /Untrusted baseUrl/);
+    assert.throws(() => validateBaseUrl('https://notweixin.qq.com.evil.com'), /Untrusted baseUrl/);
+  });
+
+  it('rejects fake subdomains', () => {
+    assert.throws(() => validateBaseUrl('https://weixin.qq.com.evil.com'), /Untrusted baseUrl/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. CDN query param injection prevention
+// ---------------------------------------------------------------------------
+
+function validateCdnQueryParam(encryptQueryParam: string): void {
+  if (!/^[A-Za-z0-9%=&+._~-]+$/.test(encryptQueryParam)) {
+    throw new Error('Invalid CDN query parameter');
+  }
+}
+
+describe('CDN query param injection', () => {
+  it('accepts normal URL-safe query params', () => {
+    assert.doesNotThrow(() => validateCdnQueryParam('key=abc123&token=xyz'));
+    assert.doesNotThrow(() => validateCdnQueryParam('enc%3Dvalue'));
+    assert.doesNotThrow(() => validateCdnQueryParam('a=1&b=2&c=3'));
+  });
+
+  it('rejects characters that could break out of query string', () => {
+    assert.throws(() => validateCdnQueryParam('key=val\nHost: evil'), /Invalid CDN/);
+    assert.throws(() => validateCdnQueryParam('key=val;drop table'), /Invalid CDN/);
+    assert.throws(() => validateCdnQueryParam('<script>'), /Invalid CDN/);
+  });
+
+  it('rejects empty string', () => {
+    assert.throws(() => validateCdnQueryParam(''), /Invalid CDN/);
+  });
+});

--- a/src/tests/split-message.test.ts
+++ b/src/tests/split-message.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Re-implement splitMessage since it's not exported
+const MAX_MESSAGE_LENGTH = 2048;
+
+function splitMessage(text: string, maxLen: number = MAX_MESSAGE_LENGTH): string[] {
+  if (text.length <= maxLen) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      chunks.push(remaining);
+      break;
+    }
+    let splitIdx = remaining.lastIndexOf('\n', maxLen);
+    if (splitIdx < maxLen * 0.3) {
+      splitIdx = maxLen;
+    }
+    chunks.push(remaining.slice(0, splitIdx));
+    remaining = remaining.slice(splitIdx).replace(/^\n+/, '');
+  }
+  return chunks;
+}
+
+describe('splitMessage', () => {
+  it('returns single chunk for short text', () => {
+    const result = splitMessage('hello');
+    assert.deepStrictEqual(result, ['hello']);
+  });
+
+  it('returns single chunk for text exactly at limit', () => {
+    const text = 'a'.repeat(2048);
+    const result = splitMessage(text);
+    assert.deepStrictEqual(result, [text]);
+  });
+
+  it('splits long text without newlines at maxLen boundary', () => {
+    const text = 'a'.repeat(5000);
+    const result = splitMessage(text);
+    assert.strictEqual(result[0].length, 2048);
+    assert.strictEqual(result[1].length, 2048);
+    assert.strictEqual(result[2].length, 904);
+    assert.strictEqual(result.join(''), text);
+  });
+
+  it('prefers splitting at newline near the limit', () => {
+    // Place a newline at position 1800 (within 30% threshold of 2048)
+    const text = 'a'.repeat(1800) + '\n' + 'b'.repeat(2000);
+    const result = splitMessage(text);
+    assert.strictEqual(result[0], 'a'.repeat(1800));
+    assert.strictEqual(result[1], 'b'.repeat(2000));
+  });
+
+  it('ignores newline too early (before 30% threshold)', () => {
+    // Newline at position 100, way too early — should hard-split at maxLen
+    const text = 'a'.repeat(100) + '\n' + 'b'.repeat(3000);
+    const result = splitMessage(text);
+    assert.strictEqual(result[0].length, 2048);
+  });
+
+  it('strips leading newlines from remainder', () => {
+    // Total length must exceed maxLen to trigger splitting
+    const text = 'a'.repeat(1900) + '\n\n\n' + 'b'.repeat(2000);
+    const result = splitMessage(text);
+    assert.strictEqual(result.length, 2);
+    assert.ok(!result[1].startsWith('\n'), 'second chunk should not start with newline');
+    assert.ok(result[1].startsWith('b'), 'second chunk should start with content');
+  });
+
+  it('handles empty string', () => {
+    assert.deepStrictEqual(splitMessage(''), ['']);
+  });
+
+  it('works with custom maxLen', () => {
+    const result = splitMessage('abcdefghij', 3);
+    assert.strictEqual(result.length, 4); // abc, def, ghi, j
+    assert.strictEqual(result.join(''), 'abcdefghij');
+  });
+});

--- a/src/wechat/accounts.ts
+++ b/src/wechat/accounts.ts
@@ -17,7 +17,15 @@ export interface AccountData {
 
 const ACCOUNTS_DIR = join(homedir(), '.wechat-claude-code', 'accounts');
 
+/** Reject accountIds containing path traversal or unexpected characters. */
+function validateAccountId(accountId: string): void {
+  if (!/^[a-zA-Z0-9_-]+$/.test(accountId)) {
+    throw new Error(`Invalid accountId: "${accountId}"`);
+  }
+}
+
 function accountPath(accountId: string): string {
+  validateAccountId(accountId);
   return join(ACCOUNTS_DIR, `${accountId}.json`);
 }
 

--- a/src/wechat/api.ts
+++ b/src/wechat/api.ts
@@ -20,6 +20,9 @@ export class WeChatApi {
   private readonly uin: string;
 
   constructor(token: string, baseUrl: string = 'https://ilinkai.weixin.qq.com') {
+    if (!baseUrl.startsWith('https://') || !/(?:^|\.)(?:weixin\.qq\.com|wechat\.com)(\/|$)/.test(baseUrl.slice('https://'.length))) {
+      throw new Error(`Untrusted baseUrl: "${baseUrl}". Must be an https://weixin.qq.com or https://wechat.com URL.`);
+    }
     this.token = token;
     this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.uin = generateUin();

--- a/src/wechat/cdn.ts
+++ b/src/wechat/cdn.ts
@@ -3,6 +3,10 @@ import { logger } from "../logger.js";
 import { CDN_BASE_URL } from "./accounts.js";
 
 export function buildCdnDownloadUrl(encryptQueryParam: string): string {
+  // Validate: only allow URL-safe characters in query param to prevent injection
+  if (!/^[A-Za-z0-9%=&+._~-]+$/.test(encryptQueryParam)) {
+    throw new Error('Invalid CDN query parameter');
+  }
   return `${CDN_BASE_URL}?${encryptQueryParam}`;
 }
 

--- a/src/wechat/login.ts
+++ b/src/wechat/login.ts
@@ -57,7 +57,7 @@ export async function waitForQrScan(qrcodeId: string): Promise<AccountData> {
   let currentQrcodeId = qrcodeId;
 
   while (true) {
-    const url = `${QR_STATUS_URL}?qrcode=${currentQrcodeId}`;
+    const url = `${QR_STATUS_URL}?qrcode=${encodeURIComponent(currentQrcodeId)}`;
 
     logger.debug('Polling QR status', { qrcodeId: currentQrcodeId });
 

--- a/src/wechat/sync-buf.ts
+++ b/src/wechat/sync-buf.ts
@@ -1,7 +1,6 @@
 import { loadJson, saveJson } from '../store.js';
 import { join } from 'node:path';
-
-const DATA_DIR = process.env.WCC_DATA_DIR || join(process.env.HOME!, '.wechat-claude-code');
+import { DATA_DIR } from '../constants.js';
 const SYNC_BUF_PATH = join(DATA_DIR, 'get_updates_buf');
 
 export function loadSyncBuf(): string {


### PR DESCRIPTION
## Summary

- **Command injection fix**: Replace `execSync` with `spawnSync` for opening QR code
- **Path traversal fix**: Validate `accountId` format before constructing file paths
- **Info leakage fix**: Return generic error messages to users, log actual errors internally
- **URL injection fix**: URL-encode query parameters in login and CDN URLs
- **SSRF prevention**: Add domain whitelist validation for `baseUrl` (weixin.qq.com / wechat.com)
- **DRY refactor**: Centralize `DATA_DIR` in `constants.ts` using `os.homedir()` instead of `process.env.HOME!`
- **Timer leak fix**: Clear old pending permission timer before creating new one
- **Error visibility**: Replace empty catch blocks with `logger.warn`

## Test plan

- [x] `tsc --noEmit` compiles with 0 errors
- [ ] `npm run setup` — QR login flow still works
- [ ] `npm run start` — message bridge functions correctly
- [ ] Verify permission request/timeout flow via WeChat

🤖 Generated with [Claude Code](https://claude.com/claude-code)