### PR TITLE
fix: add Windows and Linux compatibility

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,5 +70,7 @@ export function saveConfig(config: Config): void {
     lines.push(`permissionMode=${config.permissionMode}`);
   }
   writeFileSync(CONFIG_PATH, lines.join("\n") + "\n", "utf-8");
-  chmodSync(CONFIG_PATH, 0o600);
+  if (process.platform !== 'win32') {
+    chmodSync(CONFIG_PATH, 0o600);
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import process from 'node:process';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 
 import { WeChatApi } from './wechat/api.js';
 import { saveAccount, loadLatestAccount, type AccountData } from './wechat/accounts.js';
@@ -60,7 +61,7 @@ function promptUser(question: string, defaultValue?: string): Promise<string> {
 // ---------------------------------------------------------------------------
 
 async function runSetup(): Promise<void> {
-  const DATA_DIR = join(process.env.HOME!, '.wechat-claude-code');
+  const DATA_DIR = join(homedir(), '.wechat-claude-code');
   mkdirSync(DATA_DIR, { recursive: true });
   const QR_PATH = join(DATA_DIR, 'qrcode.png');
 
@@ -75,8 +76,13 @@ async function runSetup(): Promise<void> {
     const pngData = await QRCode.toBuffer(qrcodeUrl, { type: 'png', width: 400, margin: 2 });
     writeFileSync(QR_PATH, pngData);
 
-    // Open with system default viewer (Preview.app on macOS)
-    execSync(`open "${QR_PATH}"`);
+    // Open with system default viewer (cross-platform)
+    const openCmd = process.platform === 'win32'
+      ? `cmd /c start "" "${QR_PATH}"`
+      : process.platform === 'darwin'
+        ? `open "${QR_PATH}"`
+        : `xdg-open "${QR_PATH}"`;
+    execSync(openCmd);
     console.log('已打开二维码图片，请用微信扫描：');
     console.log(`图片路径: ${QR_PATH}\n`);
     console.log('等待扫码绑定...');

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,8 +1,9 @@
 import { loadJson, saveJson } from './store.js';
 import { join } from 'path';
 import { mkdirSync } from 'fs';
+import { homedir } from 'node:os';
 
-const DATA_DIR = process.env.WCC_DATA_DIR || join(process.env.HOME!, '.wechat-claude-code');
+const DATA_DIR = process.env.WCC_DATA_DIR || join(homedir(), '.wechat-claude-code');
 const SESSIONS_DIR = join(DATA_DIR, 'sessions');
 
 export type SessionState = 'idle' | 'processing' | 'waiting_permission';

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,5 +22,7 @@ export function saveJson(filePath: string, data: unknown): void {
   mkdirSync(dirname(filePath), { recursive: true });
   const raw = JSON.stringify(data, null, 2) + "\n";
   writeFileSync(filePath, raw, "utf-8");
-  chmodSync(filePath, 0o600);
+  if (process.platform !== 'win32') {
+    chmodSync(filePath, 0o600);
+  }
 }

--- a/src/wechat/sync-buf.ts
+++ b/src/wechat/sync-buf.ts
@@ -1,7 +1,8 @@
 import { loadJson, saveJson } from '../store.js';
 import { join } from 'node:path';
+import { homedir } from 'node:os';
 
-const DATA_DIR = process.env.WCC_DATA_DIR || join(process.env.HOME!, '.wechat-claude-code');
+const DATA_DIR = process.env.WCC_DATA_DIR || join(homedir(), '.wechat-claude-code');
 const SYNC_BUF_PATH = join(DATA_DIR, 'get_updates_buf');
 
 export function loadSyncBuf(): string {


### PR DESCRIPTION
## Summary

- Replace `process.env.HOME!` with `homedir()` from `node:os` in `main.ts`, `session.ts`, and `wechat/sync-buf.ts` — `HOME` is undefined on Windows, causing runtime crashes
- Use cross-platform file opener: `start` on Windows, `open` on macOS, `xdg-open` on Linux (for QR code image in setup)
- Skip `chmodSync` on Windows where Unix file permissions are not supported (`config.ts`, `store.ts`)

## Files Changed

| File | Change |
|------|--------|
| `src/main.ts` | `homedir()` + cross-platform `open` command |
| `src/session.ts` | `homedir()` instead of `process.env.HOME!` |
| `src/wechat/sync-buf.ts` | `homedir()` instead of `process.env.HOME!` |
| `src/config.ts` | Skip `chmodSync` on Windows |
| `src/store.ts` | Skip `chmodSync` on Windows |

## Test plan

- [x] `npm run build` compiles with zero errors
- [ ] `npm run setup` opens QR code image on Windows
- [ ] Daemon runs without crashes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)