### PR TITLE
feat: cross-platform support + security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A [Claude Code](https://claude.ai/claude-code) Skill that bridges personal WeCha
 - Permission approval — reply `y`/`n` in WeChat to approve Claude's tool use
 - Slash commands — `/help`, `/clear`, `/model`, `/status`, `/skills`
 - Launch any installed Claude Code skill from WeChat
-- macOS launchd daemon — auto-start on boot, auto-restart on crash
+- Cross-platform — macOS (launchd), Linux (systemd + nohup fallback)
 - Session persistence — resume conversations across messages
 
 ## Prerequisites
 
 - Node.js >= 18
-- macOS (daemon managed via launchd)
+- macOS or Linux
 - Personal WeChat account (QR code binding required)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with `@anthropic-ai/claude-agent-sdk` installed
 
@@ -52,7 +52,8 @@ A QR code image will open — scan it with WeChat. Then configure your working d
 npm run daemon -- start
 ```
 
-This registers a launchd agent for auto-start and auto-restart.
+- **macOS**: registers a launchd agent for auto-start and auto-restart
+- **Linux**: uses systemd user service (falls back to nohup if systemd unavailable)
 
 ### 3. Chat in WeChat
 
@@ -105,7 +106,7 @@ WeChat (phone) ←→ ilink bot API ←→ Node.js daemon ←→ Claude Code SDK
 - The daemon long-polls WeChat's ilink bot API for new messages
 - Messages are forwarded to Claude Code via `@anthropic-ai/claude-agent-sdk`
 - Responses are sent back to WeChat
-- A macOS launchd agent keeps the daemon running
+- Platform-native service management keeps the daemon running (launchd on macOS, systemd/nohup on Linux)
 
 ## Data
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,13 +11,13 @@
 - 权限审批——在微信中回复 `y`/`n` 控制工具执行
 - 斜杠命令——`/help`、`/clear`、`/model`、`/status`、`/skills`
 - 在微信中触发任意已安装的 Claude Code Skill
-- macOS launchd 守护进程——开机自启、崩溃自动重启
+- 跨平台——macOS（launchd）、Linux（systemd + nohup 回退）
 - 会话持久化——跨消息恢复上下文
 
 ## 前置条件
 
 - Node.js >= 18
-- macOS（daemon 通过 launchd 管理）
+- macOS 或 Linux
 - 个人微信账号（需扫码绑定）
 - 已安装 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)（含 `@anthropic-ai/claude-agent-sdk`）
 
@@ -52,7 +52,8 @@ npm run setup
 npm run daemon -- start
 ```
 
-注册 launchd 代理，实现开机自启和自动重启。
+- **macOS**：注册 launchd 代理，实现开机自启和自动重启
+- **Linux**：使用 systemd 用户服务（无 systemd 时回退到 nohup）
 
 ### 3. 在微信中聊天
 
@@ -105,7 +106,7 @@ npm run daemon -- logs     # 查看最近日志
 - 守护进程通过长轮询监听微信 ilink bot API 的新消息
 - 消息通过 `@anthropic-ai/claude-agent-sdk` 转发给 Claude Code
 - 回复发送回微信
-- macOS launchd 代理保持守护进程运行
+- 平台原生服务管理保持守护进程运行（macOS 使用 launchd，Linux 使用 systemd/nohup）
 
 ## 数据目录
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,16 @@
       "name": "wechat-claude-code",
       "version": "1.0.0",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",
-        "qrcode": "^1.5.4"
+        "qrcode": "^1.5.4",
+        "qrcode-terminal": "^0.12.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/qrcode": "^1.5.6",
+        "@types/qrcode-terminal": "^0.12.0",
         "typescript": "^5.7.0"
       }
     },
@@ -345,6 +348,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/qrcode-terminal": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/qrcode-terminal/-/qrcode-terminal-0.12.2.tgz",
+      "integrity": "sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -540,6 +550,14 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",
-    "qrcode": "^1.5.4"
+    "qrcode": "^1.5.4",
+    "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/qrcode": "^1.5.6",
+    "@types/qrcode-terminal": "^0.12.0",
     "typescript": "^5.7.0"
   },
   "keywords": ["wechat", "claude-code", "claude", "bridge", "chat", "skill"],

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -1,34 +1,56 @@
 #!/bin/bash
 set -euo pipefail
 
-DATA_DIR="${HOME}/.wechat-claude-code"
-PLIST_LABEL="com.wechat-claude-code.bridge"
-PLIST_PATH="${HOME}/Library/LaunchAgents/${PLIST_LABEL}.plist"
-PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# =============================================================================
+# wechat-claude-code cross-platform daemon manager
+# Supports: macOS (launchd) / Linux (systemd + nohup fallback)
+# =============================================================================
 
-is_loaded() {
-  launchctl print gui/$(id -u)/"${PLIST_LABEL}" &>/dev/null
+DATA_DIR="${HOME}/.wechat-claude-code"
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SERVICE_NAME="wechat-claude-code"
+
+# Platform detection
+OS_TYPE="$(uname -s)"
+
+# =============================================================================
+# macOS (launchd) functions
+# =============================================================================
+
+macos_plist_label() {
+  echo "com.wechat-claude-code.bridge"
 }
 
-case "$1" in
-  start)
-    if is_loaded; then
-      echo "Already running (or plist loaded)"
-      exit 0
-    fi
-    mkdir -p "$DATA_DIR/logs"
-    # Find node binary, resolving nvm/fnm/volta paths
-    NODE_BIN="$(command -v node || echo '/usr/local/bin/node')"
-    cat > "$PLIST_PATH" <<PLIST
+macos_plist_path() {
+  echo "${HOME}/Library/LaunchAgents/$(macos_plist_label).plist"
+}
+
+macos_is_loaded() {
+  launchctl print "gui/$(id -u)/$(macos_plist_label)" &>/dev/null
+}
+
+macos_start() {
+  local plist_label="$(macos_plist_label)"
+  local plist_path="$(macos_plist_path)"
+  local node_bin="$(command -v node || echo '/usr/local/bin/node')"
+
+  if macos_is_loaded; then
+    echo "Already running (or plist loaded)"
+    exit 0
+  fi
+
+  mkdir -p "$DATA_DIR/logs"
+
+  cat > "$plist_path" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>${PLIST_LABEL}</string>
+  <string>${plist_label}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${NODE_BIN}</string>
+    <string>${node_bin}</string>
     <string>${PROJECT_DIR}/dist/main.js</string>
     <string>start</string>
   </array>
@@ -45,56 +67,337 @@ case "$1" in
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${NODE_BIN%/*}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    <string>${node_bin%/*}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
   </dict>
 </dict>
 </plist>
 PLIST
-    launchctl load "$PLIST_PATH"
-    echo "Started wechat-claude-code daemon"
-    ;;
-  stop)
-    launchctl bootout "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true
-    rm -f "$PLIST_PATH"
-    echo "Stopped wechat-claude-code daemon"
-    ;;
-  restart)
-    "$0" stop
-    sleep 1
-    "$0" start
-    ;;
-  status)
-    if is_loaded; then
-      pid=$(pgrep -f "dist/main.js start" 2>/dev/null | head -1)
-      if [ -n "$pid" ]; then
+
+  launchctl load "$plist_path"
+  echo "Started wechat-claude-code daemon (macOS launchd)"
+}
+
+macos_stop() {
+  local plist_label="$(macos_plist_label)"
+  local plist_path="$(macos_plist_path)"
+
+  launchctl bootout "gui/$(id -u)/${plist_label}" 2>/dev/null || true
+  rm -f "$plist_path"
+  echo "Stopped wechat-claude-code daemon (macOS launchd)"
+}
+
+macos_status() {
+  if macos_is_loaded; then
+    local pid=$(pgrep -f "dist/main.js start" 2>/dev/null | head -1)
+    if [ -n "$pid" ]; then
+      echo "Running (PID: $pid)"
+    else
+      echo "Loaded but not running"
+    fi
+  else
+    echo "Not running"
+  fi
+}
+
+macos_logs() {
+  local log_dir="${DATA_DIR}/logs"
+  if [ -d "$log_dir" ]; then
+    local latest=$(ls -t "${log_dir}"/bridge-*.log 2>/dev/null | head -1)
+    if [ -n "$latest" ]; then
+      tail -100 "$latest"
+    else
+      echo "No bridge logs found. Checking stdout/stderr:"
+      for f in "${log_dir}"/stdout.log "${log_dir}"/stderr.log; do
+        if [ -f "$f" ]; then
+          echo "=== $(basename "$f") ==="
+          tail -30 "$f"
+        fi
+      done
+    fi
+  else
+    echo "No logs found"
+  fi
+}
+
+# =============================================================================
+# Linux (systemd) functions
+# =============================================================================
+
+linux_ensure_user_session() {
+  if [ -z "${XDG_RUNTIME_DIR:-}" ]; then
+    export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+    mkdir -p "$XDG_RUNTIME_DIR" 2>/dev/null || true
+  fi
+  if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+  fi
+}
+
+linux_service_file() {
+  echo "${HOME}/.config/systemd/user/${SERVICE_NAME}.service"
+}
+
+linux_pid_file() {
+  echo "${DATA_DIR}/${SERVICE_NAME}.pid"
+}
+
+linux_node_bin() {
+  local node_bin="$(command -v node 2>/dev/null || echo '')"
+  if [ -z "$node_bin" ]; then
+    local nvm_default="${NVM_DIR:-${HOME}/.nvm}/versions/node"
+    if [ -d "$nvm_default" ]; then
+      node_bin="$(find "$nvm_default" -name "node" -type f 2>/dev/null | head -1)"
+    fi
+  fi
+  echo "${node_bin:-/usr/bin/node}"
+}
+
+linux_systemd_available() {
+  linux_ensure_user_session
+  systemctl --user list-units &>/dev/null
+}
+
+linux_create_service_file() {
+  local service_file="$(linux_service_file)"
+  local node_bin="$(linux_node_bin)"
+
+  mkdir -p "$(dirname "$service_file")"
+
+  cat > "$service_file" <<SERVICE
+[Unit]
+Description=WeChat Claude Code Bridge
+Documentation=https://github.com/Wechat-ggGitHub/wechat-claude-code
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${node_bin} ${PROJECT_DIR}/dist/main.js start
+WorkingDirectory=${PROJECT_DIR}
+Restart=always
+RestartSec=10
+Environment=PATH=${node_bin%/*}:/usr/local/bin:/usr/bin:/bin
+StandardOutput=append:${DATA_DIR}/logs/stdout.log
+StandardError=append:${DATA_DIR}/logs/stderr.log
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target
+SERVICE
+
+  chmod 644 "$service_file"
+}
+
+linux_reload_daemon() {
+  linux_ensure_user_session
+  systemctl --user daemon-reload 2>/dev/null || true
+}
+
+linux_direct_start() {
+  local pid_file="$(linux_pid_file)"
+  local node_bin="$(linux_node_bin)"
+
+  if [ -f "$pid_file" ]; then
+    local old_pid=$(cat "$pid_file" 2>/dev/null)
+    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+      echo "Already running (PID: $old_pid)"
+      exit 0
+    fi
+    rm -f "$pid_file"
+  fi
+
+  mkdir -p "$DATA_DIR/logs"
+
+  echo "Starting wechat-claude-code daemon (direct mode)..."
+  nohup "$node_bin" "${PROJECT_DIR}/dist/main.js" start \
+    >> "$DATA_DIR/logs/stdout.log" \
+    2>> "$DATA_DIR/logs/stderr.log" &
+  local pid=$!
+  echo "$pid" > "$pid_file"
+  echo "Started (PID: $pid)"
+  echo "Logs: $DATA_DIR/logs/stdout.log"
+}
+
+linux_direct_stop() {
+  local pid_file="$(linux_pid_file)"
+
+  if [ ! -f "$pid_file" ]; then
+    echo "Not running (no PID file)"
+    exit 0
+  fi
+
+  local pid=$(cat "$pid_file" 2>/dev/null)
+  if [ -z "$pid" ]; then
+    rm -f "$pid_file"
+    echo "Stopped"
+    exit 0
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    local count=0
+    while kill -0 "$pid" 2>/dev/null && [ $count -lt 10 ]; do
+      sleep 1
+      count=$((count + 1))
+    done
+    kill -9 "$pid" 2>/dev/null || true
+    echo "Stopped (PID: $pid)"
+  else
+    echo "Process not running (cleaning up PID file)"
+  fi
+
+  rm -f "$pid_file"
+}
+
+linux_direct_status() {
+  local pid_file="$(linux_pid_file)"
+
+  if [ ! -f "$pid_file" ]; then
+    echo "Not running"
+    exit 0
+  fi
+
+  local pid=$(cat "$pid_file" 2>/dev/null)
+  if [ -z "$pid" ]; then
+    echo "Not running (invalid PID file)"
+    exit 0
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "Running (PID: $pid)"
+  else
+    echo "Not running (stale PID file)"
+  fi
+}
+
+linux_start() {
+  if linux_systemd_available; then
+    local service_file="$(linux_service_file)"
+
+    if systemctl --user is-active --quiet "${SERVICE_NAME}" 2>/dev/null; then
+      echo "Already running"
+      exit 0
+    fi
+
+    mkdir -p "$DATA_DIR/logs"
+    linux_create_service_file
+    linux_reload_daemon
+
+    systemctl --user start "${SERVICE_NAME}"
+    systemctl --user enable "${SERVICE_NAME}" 2>/dev/null || true
+    echo "Started wechat-claude-code daemon (Linux systemd)"
+  else
+    echo "Note: systemd user session not available, using direct mode"
+    echo "To enable systemd mode, run: 'loginctl enable-linger $(whoami)'"
+    echo ""
+    linux_direct_start
+  fi
+}
+
+linux_stop() {
+  if linux_systemd_available && systemctl --user cat "${SERVICE_NAME}" &>/dev/null; then
+    systemctl --user stop "${SERVICE_NAME}" 2>/dev/null || true
+    systemctl --user disable "${SERVICE_NAME}" 2>/dev/null || true
+    echo "Stopped wechat-claude-code daemon (Linux systemd)"
+  else
+    linux_direct_stop
+  fi
+}
+
+linux_restart() {
+  linux_stop
+  sleep 1
+  linux_start
+}
+
+linux_status() {
+  if linux_systemd_available && systemctl --user cat "${SERVICE_NAME}" &>/dev/null; then
+    if systemctl --user is-active --quiet "${SERVICE_NAME}" 2>/dev/null; then
+      local pid=$(systemctl --user show-property --value=MainPID "${SERVICE_NAME}" 2>/dev/null)
+      if [ -n "$pid" ] && [ "$pid" != "0" ]; then
         echo "Running (PID: $pid)"
       else
-        echo "Loaded but not running"
+        echo "Active"
       fi
     else
       echo "Not running"
     fi
-    ;;
-  logs)
-    LOG_DIR="${DATA_DIR}/logs"
-    if [ -d "$LOG_DIR" ]; then
-      latest=$(ls -t "${LOG_DIR}"/bridge-*.log 2>/dev/null | head -1)
-      if [ -n "$latest" ]; then
-        tail -100 "$latest"
-      else
-        echo "No bridge logs found. Checking stdout/stderr:"
-        for f in "${LOG_DIR}"/stdout.log "${LOG_DIR}"/stderr.log; do
-          if [ -f "$f" ]; then
-            echo "=== $(basename "$f") ==="
-            tail -30 "$f"
-          fi
-        done
-      fi
-    else
-      echo "No logs found"
+
+    if systemctl --user cat "${SERVICE_NAME}" &>/dev/null; then
+      echo ""
+      systemctl --user status "${SERVICE_NAME}" --no-pager 2>/dev/null || true
     fi
-    ;;
-  *)
-    echo "Usage: daemon.sh {start|stop|restart|status|logs}"
-    ;;
-esac
+  else
+    linux_direct_status
+  fi
+}
+
+linux_logs() {
+  if command -v journalctl >/dev/null 2>&1; then
+    if journalctl --user --unit="${SERVICE_NAME}" --quiet &>/dev/null; then
+      echo "=== systemd journal logs (last 100 lines) ==="
+      journalctl --user --unit="${SERVICE_NAME}" --no-pager -n 100 2>/dev/null || true
+      echo ""
+      echo "=== File logs ==="
+    fi
+  fi
+
+  local log_dir="${DATA_DIR}/logs"
+  if [ -d "$log_dir" ]; then
+    for f in "${log_dir}"/stdout.log "${log_dir}"/stderr.log; do
+      if [ -f "$f" ]; then
+        echo "=== $(basename "$f") ==="
+        tail -50 "$f"
+        echo ""
+      fi
+    done
+  else
+    echo "No logs found"
+  fi
+}
+
+# =============================================================================
+# Main dispatcher
+# =============================================================================
+
+main() {
+  local command="${1:-}"
+
+  case "$OS_TYPE" in
+    Darwin)
+      case "$command" in
+        start)   macos_start ;;
+        stop)    macos_stop ;;
+        restart) macos_stop; sleep 1; macos_start ;;
+        status)  macos_status ;;
+        logs)    macos_logs ;;
+        *)
+          echo "Usage: daemon.sh {start|stop|restart|status|logs}"
+          echo "Platform: macOS (launchd)"
+          exit 1
+          ;;
+      esac
+      ;;
+    Linux)
+      case "$command" in
+        start)   linux_start ;;
+        stop)    linux_stop ;;
+        restart) linux_restart ;;
+        status)  linux_status ;;
+        logs)    linux_logs ;;
+        *)
+          echo "Usage: daemon.sh {start|stop|restart|status|logs}"
+          echo "Platform: Linux (systemd)"
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "Error: Unsupported platform '$OS_TYPE'"
+      echo "Supported platforms: macOS (Darwin), Linux"
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,5 +71,7 @@ export function saveConfig(config: Config): void {
     lines.push(`permissionMode=${config.permissionMode}`);
   }
   writeFileSync(CONFIG_PATH, lines.join("\n") + "\n", "utf-8");
-  chmodSync(CONFIG_PATH, 0o600);
+  if (process.platform !== 'win32') {
+    chmodSync(CONFIG_PATH, 0o600);
+  }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const DATA_DIR = process.env.WCC_DATA_DIR || join(homedir(), '.wechat-claude-code');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import { createInterface } from 'node:readline';
 import process from 'node:process';
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
 
 import { WeChatApi } from './wechat/api.js';
 import { saveAccount, loadLatestAccount, type AccountData } from './wechat/accounts.js';
@@ -16,6 +16,7 @@ import { routeCommand, type CommandContext, type CommandResult } from './command
 import { claudeQuery, type QueryOptions } from './claude/provider.js';
 import { loadConfig, saveConfig } from './config.js';
 import { logger } from './logger.js';
+import { DATA_DIR } from './constants.js';
 import { MessageType, type WeixinMessage } from './wechat/types.js';
 
 // ---------------------------------------------------------------------------
@@ -55,30 +56,73 @@ function promptUser(question: string, defaultValue?: string): Promise<string> {
   });
 }
 
+/** Open a file using the platform's default application (secure: uses spawnSync) */
+function openFile(filePath: string): void {
+  const platform = process.platform;
+  let cmd: string;
+  let args: string[];
+
+  if (platform === 'darwin') {
+    cmd = 'open';
+    args = [filePath];
+  } else if (platform === 'win32') {
+    cmd = 'cmd';
+    args = ['/c', 'start', '', filePath];
+  } else {
+    // Linux: try xdg-open
+    cmd = 'xdg-open';
+    args = [filePath];
+  }
+
+  const result = spawnSync(cmd, args, { stdio: 'ignore' });
+  if (result.error) {
+    logger.warn('Failed to open file', { cmd, filePath, error: result.error.message });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 
 async function runSetup(): Promise<void> {
-  const DATA_DIR = join(process.env.HOME!, '.wechat-claude-code');
   mkdirSync(DATA_DIR, { recursive: true });
   const QR_PATH = join(DATA_DIR, 'qrcode.png');
 
   console.log('正在设置...\n');
 
-  // Loop: generate QR → open image → poll for scan → handle expiry → repeat
+  // Loop: generate QR → display → poll for scan → handle expiry → repeat
   while (true) {
     const { qrcodeUrl, qrcodeId } = await startQrLogin();
 
-    // Generate QR code as PNG image
-    const QRCode = await import('qrcode');
-    const pngData = await QRCode.toBuffer(qrcodeUrl, { type: 'png', width: 400, margin: 2 });
-    writeFileSync(QR_PATH, pngData);
+    const isHeadlessLinux = process.platform === 'linux' &&
+      !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
 
-    // Open with system default viewer (Preview.app on macOS)
-    execSync(`open "${QR_PATH}"`);
-    console.log('已打开二维码图片，请用微信扫描：');
-    console.log(`图片路径: ${QR_PATH}\n`);
+    if (isHeadlessLinux) {
+      // Headless Linux: display QR in terminal using qrcode-terminal
+      try {
+        const qrcodeTerminal = await import('qrcode-terminal');
+        console.log('请用微信扫描下方二维码：\n');
+        qrcodeTerminal.default.generate(qrcodeUrl, { small: true });
+        console.log();
+        console.log('二维码链接：', qrcodeUrl);
+        console.log();
+      } catch {
+        logger.warn('qrcode-terminal not available, falling back to URL');
+        console.log('无法在终端显示二维码，请访问链接：');
+        console.log(qrcodeUrl);
+        console.log();
+      }
+    } else {
+      // macOS / Windows / GUI Linux: generate QR PNG and open with system viewer
+      const QRCode = await import('qrcode');
+      const pngData = await QRCode.toBuffer(qrcodeUrl, { type: 'png', width: 400, margin: 2 });
+      writeFileSync(QR_PATH, pngData);
+
+      openFile(QR_PATH);
+      console.log('已打开二维码图片，请用微信扫描：');
+      console.log(`图片路径: ${QR_PATH}\n`);
+    }
+
     console.log('等待扫码绑定...');
 
     try {
@@ -95,7 +139,9 @@ async function runSetup(): Promise<void> {
   }
 
   // Clean up QR image
-  try { unlinkSync(QR_PATH); } catch {}
+  try { unlinkSync(QR_PATH); } catch {
+    logger.warn('Failed to clean up QR image', { path: QR_PATH });
+  }
 
   const workingDir = await promptUser('请输入工作目录', process.cwd());
   const config = loadConfig();
@@ -126,7 +172,9 @@ async function runDaemon(): Promise<void> {
   const permissionBroker = createPermissionBroker(async () => {
     try {
       await sender.sendText(account.userId ?? '', sharedCtx.lastContextToken, '⏰ 权限请求超时，已自动拒绝。');
-    } catch {}
+    } catch {
+      logger.warn('Failed to send permission timeout message');
+    }
   });
 
   // -- Wire the monitor callbacks --
@@ -382,9 +430,10 @@ async function sendToClaude(
 
     const result = await claudeQuery(queryOptions);
 
-    // Send result back to WeChat
+    // Send result back to WeChat (show generic error to user, log details internally)
     if (result.error) {
-      await sender.sendText(fromUserId, contextToken, `⚠️ 错误: ${result.error}`);
+      logger.error('Claude query error', { error: result.error });
+      await sender.sendText(fromUserId, contextToken, '⚠️ Claude 处理请求时出错，请稍后重试。');
     } else if (result.text) {
       const chunks = splitMessage(result.text);
       for (const chunk of chunks) {
@@ -401,7 +450,7 @@ async function sendToClaude(
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
     logger.error('Error in sendToClaude', { error: errorMsg });
-    await sender.sendText(fromUserId, contextToken, `⚠️ 处理消息时出错: ${errorMsg}`);
+    await sender.sendText(fromUserId, contextToken, '⚠️ 处理消息时出错，请稍后重试。');
 
     // Reset state
     session.state = 'idle';
@@ -417,12 +466,14 @@ const command = process.argv[2];
 
 if (command === 'setup') {
   runSetup().catch((err) => {
+    logger.error('Setup failed', { error: err instanceof Error ? err.message : String(err) });
     console.error('设置失败:', err);
     process.exit(1);
   });
 } else {
   // 'start' or no argument
   runDaemon().catch((err) => {
+    logger.error('Daemon start failed', { error: err instanceof Error ? err.message : String(err) });
     console.error('启动失败:', err);
     process.exit(1);
   });

--- a/src/permission.ts
+++ b/src/permission.ts
@@ -11,6 +11,15 @@ export function createPermissionBroker(onTimeout?: OnPermissionTimeout) {
   const timedOut = new Map<string, number>(); // accountId → timestamp
 
   function createPending(accountId: string, toolName: string, toolInput: string): Promise<boolean> {
+    // Clear any existing pending permission for this account to prevent timer leak
+    const existing = pending.get(accountId);
+    if (existing) {
+      clearTimeout(existing.timer);
+      pending.delete(accountId);
+      existing.resolve(false);
+      logger.warn('Replaced existing pending permission', { accountId, toolName: existing.toolName });
+    }
+
     timedOut.delete(accountId); // clear any previous timeout flag
     return new Promise<boolean>((resolve) => {
       const timer = setTimeout(() => {

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,8 +1,8 @@
 import { loadJson, saveJson } from './store.js';
-import { join } from 'path';
 import { mkdirSync } from 'fs';
+import { DATA_DIR } from './constants.js';
+import { join } from 'path';
 
-const DATA_DIR = process.env.WCC_DATA_DIR || join(process.env.HOME!, '.wechat-claude-code');
 const SESSIONS_DIR = join(DATA_DIR, 'sessions');
 
 export type SessionState = 'idle' | 'processing' | 'waiting_permission';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { logger } from "./logger.js";
 
 /**
  * Load a JSON file, returning a typed object or the fallback if the file
@@ -9,7 +10,11 @@ export function loadJson<T>(filePath: string, fallback: T): T {
   try {
     const raw = readFileSync(filePath, "utf-8");
     return JSON.parse(raw) as T;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      logger.warn('loadJson failed, using fallback', { filePath, error: err instanceof Error ? err.message : String(err) });
+    }
     return fallback;
   }
 }
@@ -22,5 +27,7 @@ export function saveJson(filePath: string, data: unknown): void {
   mkdirSync(dirname(filePath), { recursive: true });
   const raw = JSON.stringify(data, null, 2) + "\n";
   writeFileSync(filePath, raw, "utf-8");
-  chmodSync(filePath, 0o600);
+  if (process.platform !== 'win32') {
+    chmodSync(filePath, 0o600);
+  }
 }

--- a/src/wechat/accounts.ts
+++ b/src/wechat/accounts.ts
@@ -17,7 +17,15 @@ export interface AccountData {
 
 const ACCOUNTS_DIR = join(homedir(), '.wechat-claude-code', 'accounts');
 
+/** Reject accountIds containing path traversal or unexpected characters. */
+function validateAccountId(accountId: string): void {
+  if (!/^[a-zA-Z0-9_.@=-]+$/.test(accountId)) {
+    throw new Error(`Invalid accountId: "${accountId}"`);
+  }
+}
+
 function accountPath(accountId: string): string {
+  validateAccountId(accountId);
   return join(ACCOUNTS_DIR, `${accountId}.json`);
 }
 

--- a/src/wechat/api.ts
+++ b/src/wechat/api.ts
@@ -20,6 +20,10 @@ export class WeChatApi {
   private readonly uin: string;
 
   constructor(token: string, baseUrl: string = 'https://ilinkai.weixin.qq.com') {
+    if (baseUrl && (!baseUrl.startsWith('https://') || !/(?:^|\.)(?:weixin\.qq\.com|wechat\.com)(\/|$)/.test(baseUrl.slice('https://'.length)))) {
+      logger.warn('Untrusted baseUrl, using default', { baseUrl });
+      baseUrl = 'https://ilinkai.weixin.qq.com';
+    }
     this.token = token;
     this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.uin = generateUin();

--- a/src/wechat/cdn.ts
+++ b/src/wechat/cdn.ts
@@ -3,6 +3,9 @@ import { logger } from "../logger.js";
 import { CDN_BASE_URL } from "./accounts.js";
 
 export function buildCdnDownloadUrl(encryptQueryParam: string): string {
+  if (!/^[A-Za-z0-9%=&+._~-]+$/.test(encryptQueryParam)) {
+    throw new Error('Invalid CDN query parameter');
+  }
   return `${CDN_BASE_URL}?${encryptQueryParam}`;
 }
 

--- a/src/wechat/login.ts
+++ b/src/wechat/login.ts
@@ -57,7 +57,7 @@ export async function waitForQrScan(qrcodeId: string): Promise<AccountData> {
   let currentQrcodeId = qrcodeId;
 
   while (true) {
-    const url = `${QR_STATUS_URL}?qrcode=${currentQrcodeId}`;
+    const url = `${QR_STATUS_URL}?qrcode=${encodeURIComponent(currentQrcodeId)}`;
 
     logger.debug('Polling QR status', { qrcodeId: currentQrcodeId });
 

--- a/src/wechat/sync-buf.ts
+++ b/src/wechat/sync-buf.ts
@@ -1,7 +1,7 @@
 import { loadJson, saveJson } from '../store.js';
+import { DATA_DIR } from '../constants.js';
 import { join } from 'node:path';
 
-const DATA_DIR = process.env.WCC_DATA_DIR || join(process.env.HOME!, '.wechat-claude-code');
 const SYNC_BUF_PATH = join(DATA_DIR, 'get_updates_buf');
 
 export function loadSyncBuf(): string {


### PR DESCRIPTION
## Summary

集成三个社区 PR 的精华，统一解决跨平台兼容性和安全问题。

### 从 PR #4 (@wangjialiang678) 采纳 — 安全加固
- 命令注入防护：`execSync` → `spawnSync`
- 路径穿越防护：accountId 正则校验
- SSRF 防护：baseUrl 白名单验证
- 信息泄露修复：用户端显示通用错误，内部记录详细日志
- URL 注入修复：`encodeURIComponent` 包裹 qrcodeId
- Timer 泄漏修复：创建新 pending 前清理旧的
- 集中 DATA_DIR 到 `constants.ts`

### 从 PR #5 (@dopawei) 采纳 — 跨平台基础
- `homedir()` 替换 `process.env.HOME!`
- Windows 跳过 `chmodSync`

### 从 PR #2 (@zmoon460) 采纳 — Linux 支持
- `daemon.sh` 完整重写：macOS launchd + Linux systemd + nohup 回退
- 无头 Linux 用 `qrcode-terminal` 显示终端二维码
- 新增 `qrcode-terminal` 依赖

### 保留的现有功能
- 权限竞态修复（120s 超时 + 15s grace period）
- `/permission auto` 危险模式
- 所有斜杠命令（`/model`, `/clear`, `/status`, `/skills`）

### 与原始 PR 的差异
- PR #5 的 xdg-open 方案未采纳，使用 PR #2 的 qrcode-terminal（更适合无头环境）
- PR #4 的 baseUrl throw 修改为 warn + 默认值，不导致启动崩溃
- PR #4 的 accountId 正则放宽，允许 `.`、`@`、`=` 字符
- PR #4 的测试文件暂未集成（需要修复 import 方式）

Closes #2, Closes #4, Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)