### PR TITLE
fix: auto-retry without resume when session is corrupted

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -435,7 +435,16 @@ async function sendToClaude(
           },
     };
 
-    const result = await claudeQuery(queryOptions);
+    let result = await claudeQuery(queryOptions);
+
+    // If resume failed (e.g. corrupted session), retry without resume
+    if (result.error && queryOptions.resume) {
+      logger.warn('Resume failed, retrying without resume', { error: result.error, sessionId: queryOptions.resume });
+      queryOptions.resume = undefined;
+      session.sdkSessionId = undefined;
+      sessionStore.save(account.accountId, session);
+      result = await claudeQuery(queryOptions);
+    }
 
     // Send result back to WeChat (show generic error to user, log details internally)
     if (result.error) {


### PR DESCRIPTION
When a Claude SDK session becomes corrupted, resuming it causes the process to exit with code 1. This adds automatic retry logic: if a resume attempt fails, the session ID is cleared and the query is retried as a fresh session, preventing persistent failures.