### PR TITLE
fix: daemon 环境缺失导致 Claude SDK 持续报错

### DIFF
--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -67,7 +67,7 @@ macos_start() {
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${node_bin%/*}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    <string>${HOME}/.local/bin:${node_bin%/*}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
   </dict>
 </dict>
 </plist>
@@ -175,7 +175,7 @@ ExecStart=${node_bin} ${PROJECT_DIR}/dist/main.js start
 WorkingDirectory=${PROJECT_DIR}
 Restart=always
 RestartSec=10
-Environment=PATH=${node_bin%/*}:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=${HOME}/.local/bin:${node_bin%/*}:/usr/local/bin:/usr/bin:/bin
 StandardOutput=append:${DATA_DIR}/logs/stdout.log
 StandardError=append:${DATA_DIR}/logs/stderr.log
 NoNewPrivileges=true

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -41,6 +41,16 @@ macos_start() {
 
   mkdir -p "$DATA_DIR/logs"
 
+  # Collect Anthropic/Claude env vars for plist
+  local plist_extra_env=""
+  for var in ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL CLAUDE_API_KEY; do
+    if [ -n "${!var:-}" ]; then
+      plist_extra_env="${plist_extra_env}    <key>${var}</key>
+    <string>${!var}</string>
+"
+    fi
+  done
+
   cat > "$plist_path" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -68,7 +78,7 @@ macos_start() {
   <dict>
     <key>PATH</key>
     <string>${HOME}/.local/bin:${node_bin%/*}:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
-  </dict>
+${plist_extra_env}  </dict>
 </dict>
 </plist>
 PLIST
@@ -163,6 +173,15 @@ linux_create_service_file() {
 
   mkdir -p "$(dirname "$service_file")"
 
+  # Collect Anthropic/Claude env vars to pass through to the service
+  local extra_env=""
+  for var in ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL CLAUDE_API_KEY; do
+    if [ -n "${!var:-}" ]; then
+      extra_env="${extra_env}Environment=${var}=${!var}
+"
+    fi
+  done
+
   cat > "$service_file" <<SERVICE
 [Unit]
 Description=WeChat Claude Code Bridge
@@ -176,7 +195,7 @@ WorkingDirectory=${PROJECT_DIR}
 Restart=always
 RestartSec=10
 Environment=PATH=${HOME}/.local/bin:${node_bin%/*}:/usr/local/bin:/usr/bin:/bin
-StandardOutput=append:${DATA_DIR}/logs/stdout.log
+${extra_env}StandardOutput=append:${DATA_DIR}/logs/stdout.log
 StandardError=append:${DATA_DIR}/logs/stderr.log
 NoNewPrivileges=true
 PrivateTmp=true

--- a/src/main.ts
+++ b/src/main.ts
@@ -435,7 +435,16 @@ async function sendToClaude(
           },
     };
 
-    const result = await claudeQuery(queryOptions);
+    let result = await claudeQuery(queryOptions);
+
+    // If resume failed (e.g. corrupted session), retry without resume
+    if (result.error && queryOptions.resume) {
+      logger.warn('Resume failed, retrying without resume', { error: result.error, sessionId: queryOptions.resume });
+      queryOptions.resume = undefined;
+      session.sdkSessionId = undefined;
+      sessionStore.save(account.accountId, session);
+      result = await claudeQuery(queryOptions);
+    }
 
     // Send result back to WeChat (show generic error to user, log details internally)
     if (result.error) {


### PR DESCRIPTION
问题                                                                                                                      

  在 Linux (systemd) 和 macOS (launchd) 上，daemon 启动后所有消息都返回 ⚠️  Claude 处理请求时出错，请稍后重试，Claude SDK      
  进程以 exit code 1 退出。
                                                                                                                              
  根本原因有两个：                                          

  1. 缺少 API 认证环境变量：daemon.sh 生成的 service 文件没有传递 ANTHROPIC_AUTH_TOKEN、ANTHROPIC_BASE_URL 等环境变量，导致     Claude SDK 报 Invalid API key
  2. PATH 不完整：~/.local/bin 未包含在 daemon PATH 中，Claude CLI 二进制文件无法被 SDK 找到                                  
                                                                                                                              
  此外，当 session 损坏时（如进程异常退出后残留的 session ID），每次消息都会尝试 resume 该损坏 session                        
  并持续失败，没有自动恢复机制。                                                                                              
                                                                                                                              
  修复                                                      

  scripts/daemon.sh

  - 生成 systemd service / launchd plist 时，自动从当前 shell 捕获                                                            
  ANTHROPIC_AUTH_TOKEN、ANTHROPIC_API_KEY、ANTHROPIC_BASE_URL、CLAUDE_API_KEY 并写入 service 配置
  - PATH 中增加 $HOME/.local/bin（Claude CLI 的默认安装位置）                                                                 
                                                                                                                              
  src/main.ts
                                                                                                                              
  - 当 resume 失败时，自动清除 session ID 并以新会话重试，避免一个损坏 session 导致后续所有消息永久失败                       
  
  测试                                                                                                                        
                                                            
  - 在缺少 API 环境变量的 systemd 环境中验证修复后可正常对话                                                                  
  - macOS launchd 环境验证
  - 手动损坏 session ID 后验证自动恢复