### PR TITLE
feat: add /reload and /bash slash commands

### DIFF
--- a/src/commands/handlers.ts
+++ b/src/commands/handlers.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import type { CommandContext, CommandResult } from './router.js';
 import { scanAllSkills, formatSkillList, findSkill, type SkillInfo } from '../claude/skill-scanner.js';
 
@@ -10,6 +11,8 @@ const HELP_TEXT = `可用命令：
   /permission <模式> 切换权限模式
   /status           查看当前会话状态
   /skills           列出已安装的 skill
+  /reload           重新加载 skill 列表
+  /bash <命令>      执行 bash 命令
   /<skill> [参数]   触发已安装的 skill
 
 直接输入文字即可与 Claude Code 对话`;
@@ -115,6 +118,50 @@ export function handleSkills(): CommandResult {
   }
   const lines = skills.map(s => `/${s.name} — ${s.description}`);
   return { reply: `📋 已安装的 Skill (${skills.length}):\n\n${lines.join('\n')}`, handled: true };
+}
+
+export function handleReload(): CommandResult {
+  invalidateSkillCache();
+  const skills = getSkills();
+  return {
+    reply: `✅ Skill 已重新加载 (${skills.length} 个):\n\n${skills.map(s => `/${s.name} — ${s.description}`).join('\n')}`,
+    handled: true,
+  };
+}
+
+const BASH_TIMEOUT = 30_000; // 30 seconds
+const BASH_MAX_OUTPUT = 4000; // max chars to return
+
+export function handleBash(ctx: CommandContext, args: string): CommandResult {
+  if (!args) {
+    return { reply: '用法: /bash <命令>\n例: /bash ls -la', handled: true };
+  }
+
+  const cwd = ctx.session.workingDirectory;
+  try {
+    const output = execSync(args, {
+      cwd,
+      timeout: BASH_TIMEOUT,
+      maxBuffer: 1024 * 1024,
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: process.env.HOME },
+    });
+    const trimmed = output.length > BASH_MAX_OUTPUT
+      ? output.slice(0, BASH_MAX_OUTPUT) + `\n... (截断，共 ${output.length} 字符)`
+      : output;
+    return { reply: trimmed || '(无输出)', handled: true };
+  } catch (err: any) {
+    const stderr = err.stderr?.toString() || '';
+    const stdout = err.stdout?.toString() || '';
+    const combined = (stdout + '\n' + stderr).trim();
+    const trimmed = combined.length > BASH_MAX_OUTPUT
+      ? combined.slice(0, BASH_MAX_OUTPUT) + `\n... (截断)`
+      : combined;
+    return {
+      reply: `⚠️ 退出码 ${err.status ?? 'unknown'}\n${trimmed || err.message}`,
+      handled: true,
+    };
+  }
 }
 
 export function handleUnknown(cmd: string, args: string): CommandResult {

--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -1,7 +1,7 @@
 import type { Session } from '../session.js';
 import { findSkill } from '../claude/skill-scanner.js';
 import { logger } from '../logger.js';
-import { handleHelp, handleClear, handleCwd, handleModel, handlePermission, handleStatus, handleSkills, handleUnknown } from './handlers.js';
+import { handleHelp, handleClear, handleCwd, handleModel, handlePermission, handleStatus, handleSkills, handleReload, handleBash, handleUnknown } from './handlers.js';
 
 export interface CommandContext {
   accountId: string;
@@ -56,6 +56,11 @@ export function routeCommand(ctx: CommandContext): CommandResult {
       return handleStatus(ctx);
     case 'skills':
       return handleSkills();
+    case 'reload':
+      return handleReload();
+    case 'bash':
+    case 'sh':
+      return handleBash(ctx, args);
     default:
       return handleUnknown(cmd, args);
   }


### PR DESCRIPTION
## Summary

  新增两个微信端斜杠命令：

  - **`/reload`** — 强制刷新 skill 缓存并重新扫描所有已安装的 skill，返回最新列表。适用于安装新 skill 后无需重启 daemon
  即可生效。
  - **`/bash <命令>`**（别名 `/sh`）— 在当前工作目录直接执行 shell 命令并返回输出。30 秒超时，输出超过 4000
  字符自动截断。命令执行失败时返回退出码和错误信息。

  ## 使用示例

  /reload
  → ✅ Skill 已重新加载 (3 个):
    /wechat-claude-code — 微信消息桥接
    /pdf — PDF 处理工具
    ...

  /bash ls -la
  → total 48
    drwxr-xr-x  5 user user 4096 ...

  /bash git status
  → On branch main
    nothing to commit, working tree clean

  ## 改动文件

  - `src/commands/handlers.ts` — 新增 `handleReload()` 和 `handleBash()` 处理函数
  - `src/commands/router.ts` — 注册 `/reload`、`/bash`、`/sh` 路由

  ## Test plan

  - [x] 微信发送 `/reload`，验证返回最新 skill 列表
  - [x] 微信发送 `/bash pwd`，验证返回当前工作目录
  - [x] 微信发送 `/bash sleep 60`，验证 30 秒超时生效
  - [x] 微信发送 `/sh echo hello`，验证别名可用
  - [x] 微信发送 `/bash`（无参数），验证返回用法提示