### PR TITLE
fix: non-blocking message processing to allow permission responses

### DIFF
--- a/src/commands/handlers.ts
+++ b/src/commands/handlers.ts
@@ -81,7 +81,7 @@ export function handlePermission(ctx: CommandContext, args: string): CommandResu
     ];
     return { reply: lines.join('\n'), handled: true };
   }
-  const mode = args.trim().toLowerCase();
+  const mode = args.trim();
   if (!PERMISSION_MODES.includes(mode as any)) {
     return {
       reply: `未知模式: ${mode}\n可用: ${PERMISSION_MODES.join(', ')}`,

--- a/src/wechat/monitor.ts
+++ b/src/wechat/monitor.ts
@@ -47,7 +47,7 @@ export function createMonitor(api: WeChatApi, callbacks: MonitorCallbacks) {
           saveSyncBuf(resp.get_updates_buf);
         }
 
-        // Process messages (with deduplication)
+        // Process messages (with deduplication) - non-blocking
         const messages = resp.msgs ?? [];
         if (messages.length > 0) {
           logger.info('Received messages', { count: messages.length });
@@ -69,12 +69,12 @@ export function createMonitor(api: WeChatApi, callbacks: MonitorCallbacks) {
                 for (const id of toDelete) recentMsgIds.delete(id);
               }
             }
-            try {
-              await callbacks.onMessage(msg);
-            } catch (err) {
+            // Fire-and-forget: process message without blocking the poll loop
+            // This allows permission responses (y/n) to be received while waiting
+            callbacks.onMessage(msg).catch((err: unknown) => {
               const msg2 = err instanceof Error ? err.message : String(err);
               logger.error('Error processing message', { error: msg2, messageId: msg.message_id });
-            }
+            });
           }
         }
 


### PR DESCRIPTION
#  commit 1:
When Claude requests tool permission, the user can now reply with y/n while the query is still processing. Previously, the poll loop was blocked waiting for the message handler, causing permission responses to be delayed until timeout.

## 问题复现
<img width="600" height="830" alt="image" src="https://github.com/user-attachments/assets/ff290624-80cf-46f8-aa03-2d6ac9215e3b" />


## 排查截图
<img width="1660" height="1582" alt="e717f605b367b5cd70aaef6d178c9aa2" src="https://github.com/user-attachments/assets/213fb7a7-b6a3-4220-80a7-8b4f6ef14123" />


## 修复效果
<img width="604" height="894" alt="image" src="https://github.com/user-attachments/assets/6e64ba90-2d92-4f9a-88c1-c3307570bc31" />

#  commit 2:
fix: case-sensitive permission mode matching
Remove toLowerCase() that converted acceptEdits to acceptedits,
causing the permission command to fail with "Unknown mode" error.

## 问题和修复截图
<img width="620" height="686" alt="image" src="https://github.com/user-attachments/assets/661169dc-9e6b-4ebb-9386-8961272491e4" />



