### PR TITLE
实时进度推送、思考预览、/prompt 命令、图片修复及多项稳定性改进

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A [Claude Code](https://claude.ai/claude-code) Skill that bridges personal WeCha
 Clone into your Claude Code skills directory:
 
 ```bash
-git clone https://github.com/zkeq/wechat-claude-code.git ~/.claude/skills/wechat-claude-code
+git clone https://github.com/Wechat-ggGitHub/wechat-claude-code.git ~/.claude/skills/wechat-claude-code
 cd ~/.claude/skills/wechat-claude-code
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ A [Claude Code](https://claude.ai/claude-code) Skill that bridges personal WeCha
 
 ## Features
 
+- **Real-time progress updates** — see Claude's tool calls (🔧 Bash, 📖 Read, 🔍 Glob…) as they happen
+- **Thinking preview** — get a 💭 preview of Claude's reasoning before each tool call
+- **Interrupt support** — send a new message mid-query to abort and redirect Claude
+- **System prompt** — set a persistent prompt via `/prompt` (e.g. "Reply in Chinese")
 - Text conversation with Claude Code through WeChat
 - Image recognition — send photos for Claude to analyze
 - Permission approval — reply `y`/`n` in WeChat to approve Claude's tool use
-- Slash commands — `/help`, `/clear`, `/model`, `/status`, `/skills`
+- Slash commands — `/help`, `/clear`, `/model`, `/prompt`, `/status`, `/skills`, and more
 - Launch any installed Claude Code skill from WeChat
 - Cross-platform — macOS (launchd), Linux (systemd + nohup fallback)
 - Session persistence — resume conversations across messages
+- Rate-limit safe — automatic exponential backoff on WeChat API throttling
 
 ## Prerequisites
 
@@ -27,7 +32,7 @@ A [Claude Code](https://claude.ai/claude-code) Skill that bridges personal WeCha
 Clone into your Claude Code skills directory:
 
 ```bash
-git clone https://github.com/Wechat-ggGitHub/wechat-claude-code.git ~/.claude/skills/wechat-claude-code
+git clone https://github.com/zkeq/wechat-claude-code.git ~/.claude/skills/wechat-claude-code
 cd ~/.claude/skills/wechat-claude-code
 npm install
 ```
@@ -75,10 +80,16 @@ npm run daemon -- logs     # View recent logs
 |---------|-------------|
 | `/help` | Show available commands |
 | `/clear` | Clear current session (start fresh) |
+| `/reset` | Full reset including working directory |
 | `/model <name>` | Switch Claude model |
 | `/permission <mode>` | Switch permission mode |
+| `/prompt [text]` | View or set a system prompt appended to every query |
 | `/status` | View current session state |
+| `/cwd [path]` | View or switch working directory |
 | `/skills` | List installed Claude Code skills |
+| `/history [n]` | View last N chat messages |
+| `/compact` | Start a new SDK session (clear token context) |
+| `/undo [n]` | Remove last N messages from history |
 | `/<skill> [args]` | Trigger any installed skill |
 
 ## Permission Approval
@@ -106,7 +117,8 @@ WeChat (phone) ←→ ilink bot API ←→ Node.js daemon ←→ Claude Code SDK
 
 - The daemon long-polls WeChat's ilink bot API for new messages
 - Messages are forwarded to Claude Code via `@anthropic-ai/claude-agent-sdk`
-- Responses are sent back to WeChat
+- Tool calls and thinking previews are streamed back as Claude works
+- Responses are sent back to WeChat with automatic rate-limit retry
 - Platform-native service management keeps the daemon running (launchd on macOS, systemd/nohup on Linux)
 
 ## Data
@@ -116,7 +128,7 @@ All data is stored in `~/.wechat-claude-code/`:
 ```
 ~/.wechat-claude-code/
 ├── accounts/       # WeChat account credentials (one JSON per account)
-├── config.env      # Global config (working directory, model, permission mode)
+├── config.env      # Global config (working directory, model, permission mode, system prompt)
 ├── sessions/       # Session data (one JSON per account)
 ├── get_updates_buf # Message polling sync buffer
 └── logs/           # Rotating logs (daily, 30-day retention)

--- a/README_zh.md
+++ b/README_zh.md
@@ -32,7 +32,7 @@
 克隆到 Claude Code skills 目录：
 
 ```bash
-git clone https://github.com/zkeq/wechat-claude-code.git ~/.claude/skills/wechat-claude-code
+git clone https://github.com/Wechat-ggGitHub/wechat-claude-code.git ~/.claude/skills/wechat-claude-code
 cd ~/.claude/skills/wechat-claude-code
 npm install
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,13 +6,18 @@
 
 ## 功能特性
 
+- **实时进度推送** — 实时查看 Claude 的工具调用（🔧 Bash、📖 Read、🔍 Glob…）
+- **思考预览** — 每次工具调用前展示 💭 Claude 的推理摘要（前 300 字）
+- **中断支持** — 在 Claude 处理中发送新消息可打断当前任务
+- **系统提示词** — 通过 `/prompt` 设置持久化提示词（如"用中文回答"）
 - 通过微信与 Claude Code 进行文字对话
 - 图片识别——发送照片让 Claude 分析
 - 权限审批——在微信中回复 `y`/`n` 控制工具执行
-- 斜杠命令——`/help`、`/clear`、`/model`、`/status`、`/skills`
+- 斜杠命令——`/help`、`/clear`、`/model`、`/prompt`、`/status`、`/skills` 等
 - 在微信中触发任意已安装的 Claude Code Skill
 - 跨平台——macOS（launchd）、Linux（systemd + nohup 回退）
 - 会话持久化——跨消息恢复上下文
+- 限频保护——微信 API 限频时自动指数退避重试
 
 ## 前置条件
 
@@ -27,7 +32,7 @@
 克隆到 Claude Code skills 目录：
 
 ```bash
-git clone https://github.com/Wechat-ggGitHub/wechat-claude-code.git ~/.claude/skills/wechat-claude-code
+git clone https://github.com/zkeq/wechat-claude-code.git ~/.claude/skills/wechat-claude-code
 cd ~/.claude/skills/wechat-claude-code
 npm install
 ```
@@ -75,10 +80,16 @@ npm run daemon -- logs     # 查看最近日志
 |------|------|
 | `/help` | 显示帮助 |
 | `/clear` | 清除当前会话（重新开始） |
+| `/reset` | 完全重置（包括工作目录等设置） |
 | `/model <名称>` | 切换 Claude 模型 |
 | `/permission <模式>` | 切换权限模式 |
+| `/prompt [内容]` | 查看或设置系统提示词（全局生效） |
 | `/status` | 查看当前会话状态 |
+| `/cwd [路径]` | 查看或切换工作目录 |
 | `/skills` | 列出已安装的 Claude Code Skill |
+| `/history [数量]` | 查看最近 N 条对话记录 |
+| `/compact` | 压缩上下文（开始新 SDK 会话，保留历史） |
+| `/undo [数量]` | 撤销最近 N 条对话 |
 | `/<skill> [参数]` | 触发任意已安装的 Skill |
 
 ## 权限审批
@@ -106,7 +117,8 @@ npm run daemon -- logs     # 查看最近日志
 
 - 守护进程通过长轮询监听微信 ilink bot API 的新消息
 - 消息通过 `@anthropic-ai/claude-agent-sdk` 转发给 Claude Code
-- 回复发送回微信
+- 工具调用和思考摘要在 Claude 工作时实时推送
+- 回复发送回微信，限频时自动重试
 - 平台原生服务管理保持守护进程运行（macOS 使用 launchd，Linux 使用 systemd/nohup）
 
 ## 数据目录
@@ -116,7 +128,7 @@ npm run daemon -- logs     # 查看最近日志
 ```
 ~/.wechat-claude-code/
 ├── accounts/       # 微信账号凭证（每个账号一个 JSON）
-├── config.env      # 全局配置（工作目录、模型、权限模式）
+├── config.env      # 全局配置（工作目录、模型、权限模式、系统提示词）
 ├── sessions/       # 会话数据（每个账号一个 JSON）
 ├── get_updates_buf # 消息轮询同步缓冲
 └── logs/           # 运行日志（每日轮转，保留 30 天）

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "postinstall": "npm run build",
+    "postinstall": "npm run build && node -e \"require('fs').copyFileSync('patches/claude-cli-2.1.77.js','node_modules/@anthropic-ai/claude-agent-sdk/cli.js')\" 2>/dev/null || true",
     "start": "node dist/main.js",
     "run": "node dist/main.js start",
     "dev": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "postinstall": "npm run build && node -e \"require('fs').copyFileSync('patches/claude-cli-2.1.77.js','node_modules/@anthropic-ai/claude-agent-sdk/cli.js')\" 2>/dev/null || true",
+    "postinstall": "npm run build",
     "start": "node dist/main.js",
     "run": "node dist/main.js start",
     "dev": "tsc --watch",

--- a/src/claude/provider.ts
+++ b/src/claude/provider.ts
@@ -9,6 +9,9 @@ import {
   type PermissionResult,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../logger.js";
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -25,6 +28,8 @@ export interface QueryOptions {
     source: { type: "base64"; media_type: string; data: string };
   }>;
   onPermissionRequest?: (toolName: string, toolInput: string) => Promise<boolean>;
+  /** Called each time an assistant text chunk is produced (e.g. before/after tool calls). */
+  onText?: (text: string) => Promise<void> | void;
 }
 
 export interface QueryResult {
@@ -94,6 +99,32 @@ async function* singleUserMessage(
 }
 
 // ---------------------------------------------------------------------------
+// Resolve global claude cli.js path (avoids bundled old version in SDK)
+// ---------------------------------------------------------------------------
+
+function resolveGlobalClaudeCliPath(): string | undefined {
+  try {
+    const claudeBin = execSync("which claude", { encoding: "utf8" }).trim();
+    // Resolve symlinks to get the actual file
+    const realBin = execSync(`readlink -f "${claudeBin}" 2>/dev/null || realpath "${claudeBin}" 2>/dev/null || echo "${claudeBin}"`, { encoding: "utf8" }).trim();
+    // On npm global installs, the binary itself is cli.js
+    if (realBin.endsWith(".js") && existsSync(realBin)) return realBin;
+    // Otherwise look for cli.js next to the binary
+    const cliJs = join(dirname(realBin), "cli.js");
+    if (existsSync(cliJs)) return cliJs;
+    // Try npm global prefix
+    const npmPrefix = execSync("npm config get prefix", { encoding: "utf8" }).trim();
+    const npmCli = join(npmPrefix, "lib", "node_modules", "@anthropic-ai", "claude-code", "cli.js");
+    if (existsSync(npmCli)) return npmCli;
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+const GLOBAL_CLAUDE_CLI_PATH = resolveGlobalClaudeCliPath();
+
+// ---------------------------------------------------------------------------
 // Core function
 // ---------------------------------------------------------------------------
 
@@ -106,6 +137,7 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
     permissionMode,
     images,
     onPermissionRequest,
+    onText,
   } = options;
 
   logger.info("Starting Claude query", {
@@ -129,6 +161,12 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
     permissionMode,
     settingSources: ["user", "project"],
   };
+
+  // Use the globally installed claude cli.js to avoid version mismatch with the bundled one
+  if (GLOBAL_CLAUDE_CLI_PATH) {
+    (sdkOptions as any).pathToClaudeCodeExecutable = GLOBAL_CLAUDE_CLI_PATH;
+    logger.debug("Using global claude cli.js", { path: GLOBAL_CLAUDE_CLI_PATH });
+  }
 
   if (model) sdkOptions.model = model;
   if (resume) sdkOptions.resume = resume;
@@ -178,7 +216,10 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
       switch (message.type) {
         case "assistant": {
           const text = extractText(message as SDKAssistantMessage);
-          if (text) textParts.push(text);
+          if (text) {
+            textParts.push(text);
+            if (onText) await onText(text);
+          }
           break;
         }
         case "result": {

--- a/src/claude/provider.ts
+++ b/src/claude/provider.ts
@@ -22,6 +22,7 @@ export interface QueryOptions {
   cwd: string;
   resume?: string;
   model?: string;
+  systemPrompt?: string;
   permissionMode?: "default" | "acceptEdits" | "plan";
   images?: Array<{
     type: "image";
@@ -30,6 +31,10 @@ export interface QueryOptions {
   onPermissionRequest?: (toolName: string, toolInput: string) => Promise<boolean>;
   /** Called each time an assistant text chunk is produced (e.g. before/after tool calls). */
   onText?: (text: string) => Promise<void> | void;
+  /** Called when Claude invokes a tool, with a human-readable summary. */
+  onThinking?: (summary: string) => Promise<void> | void;
+  /** Optional abort controller to cancel the query (e.g. when user sends a new message). */
+  abortController?: AbortController;
 }
 
 export interface QueryResult {
@@ -41,6 +46,25 @@ export interface QueryResult {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Format a tool_use block into a concise human-readable summary.
+ */
+function formatToolUse(toolName: string, input: Record<string, unknown>): string {
+  const icons: Record<string, string> = {
+    Bash: "🔧", Read: "📖", Write: "✏️", Edit: "✏️", MultiEdit: "✏️",
+    Grep: "🔍", Glob: "🔍", WebFetch: "🌐", WebSearch: "🌐",
+    TodoWrite: "📝", TodoRead: "📝", Task: "🤖",
+  };
+  const icon = icons[toolName] ?? "⚙️";
+  let detail = "";
+  if (input.command) detail = String(input.command).slice(0, 80);
+  else if (input.file_path) detail = String(input.file_path);
+  else if (input.pattern) detail = String(input.pattern).slice(0, 60);
+  else if (input.query) detail = String(input.query).slice(0, 60);
+  else if (input.url) detail = String(input.url).slice(0, 60);
+  return detail ? `${icon} ${toolName}: ${detail}` : `${icon} ${toolName}`;
+}
 
 /**
  * Extract accumulated text from an SDK assistant message's content blocks.
@@ -134,10 +158,13 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
     cwd,
     resume,
     model,
+    systemPrompt,
     permissionMode,
     images,
     onPermissionRequest,
     onText,
+    onThinking,
+    abortController,
   } = options;
 
   logger.info("Starting Claude query", {
@@ -160,6 +187,7 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
     cwd,
     permissionMode,
     settingSources: ["user", "project"],
+    includePartialMessages: !!onText,
   };
 
   // Use the globally installed claude cli.js to avoid version mismatch with the bundled one
@@ -170,6 +198,10 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
 
   if (model) sdkOptions.model = model;
   if (resume) sdkOptions.resume = resume;
+  if (abortController) sdkOptions.abortController = abortController;
+  if (systemPrompt) {
+    (sdkOptions as any).systemPrompt = { type: "preset", preset: "claude_code", append: systemPrompt };
+  }
 
   // Permission callback — bridges the SDK's CanUseTool to our simpler handler.
   if (onPermissionRequest) {
@@ -202,9 +234,12 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
   }
 
   // --- Execute query & accumulate output ---
+  const MAX_THINKING_PREVIEW = 300; // max chars per thinking block shown to user
   let sessionId = "";
   const textParts: string[] = [];
   let errorMessage: string | undefined;
+  let thinkingBuf = "";      // accumulates current thinking block
+  let thinkingCapped = false; // true once we've emitted the preview for this block
 
   try {
     const result = query({ prompt: promptParam, options: sdkOptions });
@@ -215,10 +250,59 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
 
       switch (message.type) {
         case "assistant": {
-          const text = extractText(message as SDKAssistantMessage);
+          const aMsg = message as SDKAssistantMessage;
+          const content = aMsg.message?.content;
+          // Extract tool_use blocks and notify onThinking
+          if (onThinking) {
+            if (Array.isArray(content)) {
+              for (const block of content) {
+                if ((block as any).type === "tool_use") {
+                  const summary = formatToolUse(
+                    (block as any).name ?? "Tool",
+                    (block as any).input ?? {},
+                  );
+                  await onThinking(summary);
+                }
+              }
+            }
+          }
+          // Accumulate text; only call onText if not already streaming via stream_event
+          const text = extractText(aMsg);
           if (text) {
             textParts.push(text);
-            if (onText) await onText(text);
+            if (onText && !sdkOptions.includePartialMessages) await onText(text);
+          }
+          break;
+        }
+        case "stream_event": {
+          const evt = (message as any).event;
+          if (evt?.type === "content_block_start") {
+            // Reset thinking state at the start of each new block
+            if (evt?.content_block?.type === "thinking") {
+              thinkingBuf = "";
+              thinkingCapped = false;
+            }
+          } else if (evt?.type === "content_block_delta") {
+            const deltaType: string = evt.delta?.type ?? "";
+            if (deltaType === "text_delta" && onText) {
+              const delta: string = evt.delta.text;
+              if (delta) await onText(delta);
+            } else if (deltaType === "thinking_delta" && onText && !thinkingCapped) {
+              // Accumulate thinking text; emit a short preview once we hit the cap
+              thinkingBuf += (evt.delta.thinking as string) ?? "";
+              if (thinkingBuf.length >= MAX_THINKING_PREVIEW) {
+                thinkingCapped = true;
+                await onText("💭 " + thinkingBuf.slice(0, MAX_THINKING_PREVIEW).trim() + "…\n");
+                thinkingBuf = "";
+              }
+            }
+          } else if (evt?.type === "content_block_stop") {
+            // Block ended before hitting the cap — emit what we have (if non-empty)
+            if (thinkingBuf.trim() && onText && !thinkingCapped) {
+              await onText("💭 " + thinkingBuf.trim() + "\n");
+            }
+            thinkingBuf = "";
+            thinkingCapped = false;
           }
           break;
         }
@@ -246,7 +330,7 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
           break;
         }
         default:
-          // tool_progress, auth_status, stream_event, etc. — ignore
+          // tool_progress, auth_status, etc. — ignore
           break;
       }
     }

--- a/src/commands/handlers.ts
+++ b/src/commands/handlers.ts
@@ -1,5 +1,6 @@
 import type { CommandContext, CommandResult } from './router.js';
 import { scanAllSkills, formatSkillList, findSkill, type SkillInfo } from '../claude/skill-scanner.js';
+import { loadConfig, saveConfig } from '../config.js';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,6 +20,7 @@ const HELP_TEXT = `可用命令：
   /cwd [路径]       查看或切换工作目录
   /model [名称]     查看或切换 Claude 模型
   /permission [模式] 查看或切换权限模式
+  /prompt [内容]    查看或设置系统提示词（全局生效）
 
 其他：
   /skills [full]    列出已安装的 skill（full 显示描述）
@@ -205,6 +207,25 @@ export function handleVersion(): CommandResult {
   } catch {
     return { reply: 'wechat-claude-code (version unknown)', handled: true };
   }
+}
+
+export function handlePrompt(_ctx: CommandContext, args: string): CommandResult {
+  const config = loadConfig();
+  if (!args) {
+    const current = config.systemPrompt;
+    if (current) {
+      return { reply: `📝 当前系统提示词:\n${current}\n\n用法:\n/prompt <提示词>  — 设置\n/prompt clear   — 清除`, handled: true };
+    }
+    return { reply: '📝 暂无系统提示词\n\n用法: /prompt <提示词>\n例: /prompt 用中文回答我', handled: true };
+  }
+  if (args.trim().toLowerCase() === 'clear') {
+    config.systemPrompt = undefined;
+    saveConfig(config);
+    return { reply: '✅ 系统提示词已清除', handled: true };
+  }
+  config.systemPrompt = args.trim();
+  saveConfig(config);
+  return { reply: `✅ 系统提示词已设置:\n${config.systemPrompt}`, handled: true };
 }
 
 export function handleUnknown(cmd: string, args: string): CommandResult {

--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -1,7 +1,7 @@
 import type { Session } from '../session.js';
 import { findSkill } from '../claude/skill-scanner.js';
 import { logger } from '../logger.js';
-import { handleHelp, handleClear, handleCwd, handleModel, handlePermission, handleStatus, handleSkills, handleHistory, handleReset, handleCompact, handleUndo, handleVersion, handleUnknown } from './handlers.js';
+import { handleHelp, handleClear, handleCwd, handleModel, handlePermission, handleStatus, handleSkills, handleHistory, handleReset, handleCompact, handleUndo, handleVersion, handlePrompt, handleUnknown } from './handlers.js';
 
 export interface CommandContext {
   accountId: string;
@@ -56,6 +56,8 @@ export function routeCommand(ctx: CommandContext): CommandResult {
       return handleModel(ctx, args);
     case 'permission':
       return handlePermission(ctx, args);
+    case 'prompt':
+      return handlePrompt(ctx, args);
     case 'status':
       return handleStatus(ctx);
     case 'skills':

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export interface Config {
   workingDirectory: string;
   model?: string;
   permissionMode?: "default" | "acceptEdits" | "plan" | "auto";
+  systemPrompt?: string;
 }
 
 const CONFIG_DIR = join(homedir(), ".wechat-claude-code");
@@ -45,6 +46,9 @@ function parseConfigFile(content: string): Config {
           config.permissionMode = value;
         }
         break;
+      case "systemPrompt":
+        config.systemPrompt = value;
+        break;
     }
   }
   return config;
@@ -69,6 +73,9 @@ export function saveConfig(config: Config): void {
   }
   if (config.permissionMode) {
     lines.push(`permissionMode=${config.permissionMode}`);
+  }
+  if (config.systemPrompt) {
+    lines.push(`systemPrompt=${config.systemPrompt}`);
   }
   writeFileSync(CONFIG_PATH, lines.join("\n") + "\n", "utf-8");
   if (process.platform !== 'win32') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -241,15 +241,19 @@ async function handleMessage(
   const userText = extractTextFromItems(msg.item_list);
   const imageItem = extractFirstImageUrl(msg.item_list);
 
-  // Concurrency guard: reject normal messages and /clear while processing
+  // Concurrency guard: reject normal messages while processing, but allow /clear to force-reset
   if (session.state === 'processing') {
     if (userText.startsWith('/clear')) {
-      await sender.sendText(fromUserId, contextToken, '⏳ 正在处理上一条消息，请稍后再清除会话');
+      // Force reset stuck session state
+      session.state = 'idle';
+      sessionStore.save(account.accountId, session);
+      // Fall through to command routing so /clear executes normally
     } else if (!userText.startsWith('/')) {
       await sender.sendText(fromUserId, contextToken, '⏳ 正在处理上一条消息，请稍后...');
+      return;
+    } else if (!userText.startsWith('/status') && !userText.startsWith('/help')) {
+      return;
     }
-    // Allow /status and /help during processing (read-only)
-    if (!userText.startsWith('/status') && !userText.startsWith('/help')) return;
   }
 
   // -- Grace period: catch late y/n after timeout --
@@ -411,13 +415,24 @@ async function sendToClaude(
     // Map 'auto' to the SDK's underlying mode (use acceptEdits as base, but we override canUseTool)
     const sdkPermissionMode = isAutoPermission ? 'acceptEdits' : effectivePermissionMode;
 
+    // Track which text chunks have already been sent via onText streaming
+    const sentChunks: string[] = [];
+
     const queryOptions: QueryOptions = {
       prompt: userText || '请分析这张图片',
-      cwd: session.workingDirectory || config.workingDirectory,
+      cwd: (session.workingDirectory || config.workingDirectory).replace(/^~/, process.env.HOME || ''),
       resume: session.sdkSessionId,
       model: session.model,
       permissionMode: sdkPermissionMode,
       images,
+      onText: async (text: string) => {
+        // Send each assistant message block immediately as it arrives
+        const chunks = splitMessage(text);
+        for (const chunk of chunks) {
+          sentChunks.push(chunk);
+          await sender.sendText(fromUserId, contextToken, chunk);
+        }
+      },
       onPermissionRequest: isAutoPermission
         ? async () => true  // auto-approve all tools, skip broker
         : async (toolName: string, toolInput: string) => {
@@ -462,18 +477,30 @@ async function sendToClaude(
     }
 
     // Send result back to WeChat (show generic error to user, log details internally)
-    if (result.error) {
-      logger.error('Claude query error', { error: result.error });
-      await sender.sendText(fromUserId, contextToken, '⚠️ Claude 处理请求时出错，请稍后重试。');
-    } else if (result.text) {
+    // Prefer text over error: SDK sometimes exits with code 1 after successfully producing output
+    if (result.text) {
+      if (result.error) {
+        logger.warn('Claude query had error but returned text, using text', { error: result.error });
+      }
       // Record assistant response in chat history
       sessionStore.addChatMessage(session, 'assistant', result.text);
 
-      const chunks = splitMessage(result.text);
-      for (const chunk of chunks) {
+      // Send any chunks not already streamed via onText
+      const allChunks = splitMessage(result.text);
+      const sentSet = new Set(sentChunks);
+      const remaining = allChunks.filter(c => !sentSet.has(c));
+      for (const chunk of remaining) {
         await sender.sendText(fromUserId, contextToken, chunk);
       }
-    } else {
+
+      // If nothing was sent at all, send full text now
+      if (sentChunks.length === 0 && remaining.length === 0) {
+        await sender.sendText(fromUserId, contextToken, result.text);
+      }
+    } else if (result.error) {
+      logger.error('Claude query error', { error: result.error });
+      await sender.sendText(fromUserId, contextToken, '⚠️ Claude 处理请求时出错，请稍后重试。');
+    } else if (sentChunks.length === 0) {
       await sender.sendText(fromUserId, contextToken, 'ℹ️ Claude 无返回内容（可能因权限被拒而终止）');
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,7 +433,7 @@ async function sendToClaude(
     // Unified buffer: text deltas and tool summaries all go here
     let pendingBuffer = '';
     let anySent = false;
-    let lastSendTime = 0;
+    let lastSendTime = Date.now(); // start the clock now, so first delta doesn't fire immediately
     const SEND_INTERVAL_MS = 36_000;
 
     // Send everything in pendingBuffer. force=true ignores rate limit.

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,6 +176,7 @@ async function runDaemon(): Promise<void> {
 
   const sender = createSender(api, account.accountId);
   const sharedCtx = { lastContextToken: '' };
+  const activeControllers = new Map<string, AbortController>();
   const permissionBroker = createPermissionBroker(async () => {
     try {
       await sender.sendText(account.userId ?? '', sharedCtx.lastContextToken, '⏰ 权限请求超时，已自动拒绝。');
@@ -188,7 +189,7 @@ async function runDaemon(): Promise<void> {
 
   const callbacks: MonitorCallbacks = {
     onMessage: async (msg: WeixinMessage) => {
-      await handleMessage(msg, account, session, sessionStore, permissionBroker, sender, config, sharedCtx);
+      await handleMessage(msg, account, session, sessionStore, permissionBroker, sender, config, sharedCtx, activeControllers);
     },
     onSessionExpired: () => {
       logger.warn('Session expired, will keep retrying...');
@@ -228,6 +229,7 @@ async function handleMessage(
   sender: ReturnType<typeof createSender>,
   config: ReturnType<typeof loadConfig>,
   sharedCtx: { lastContextToken: string },
+  activeControllers: Map<string, AbortController>,
 ): Promise<void> {
   // Filter: only user messages with required fields
   if (msg.message_type !== MessageType.USER) return;
@@ -241,16 +243,22 @@ async function handleMessage(
   const userText = extractTextFromItems(msg.item_list);
   const imageItem = extractFirstImageUrl(msg.item_list);
 
-  // Concurrency guard: reject normal messages while processing, but allow /clear to force-reset
+  // Concurrency guard: abort current query when new message arrives
   if (session.state === 'processing') {
     if (userText.startsWith('/clear')) {
       // Force reset stuck session state
+      const ctrl = activeControllers.get(account.accountId);
+      if (ctrl) { ctrl.abort(); activeControllers.delete(account.accountId); }
       session.state = 'idle';
       sessionStore.save(account.accountId, session);
       // Fall through to command routing so /clear executes normally
     } else if (!userText.startsWith('/')) {
-      await sender.sendText(fromUserId, contextToken, '⏳ 正在处理上一条消息，请稍后...');
-      return;
+      // Abort the current query and process the new message instead
+      const ctrl = activeControllers.get(account.accountId);
+      if (ctrl) { ctrl.abort(); activeControllers.delete(account.accountId); }
+      session.state = 'idle';
+      sessionStore.save(account.accountId, session);
+      // Fall through to send new message to Claude
     } else if (!userText.startsWith('/status') && !userText.startsWith('/help')) {
       return;
     }
@@ -330,6 +338,7 @@ async function handleMessage(
         permissionBroker,
         sender,
         config,
+        activeControllers,
       );
       return;
     }
@@ -360,6 +369,7 @@ async function handleMessage(
     permissionBroker,
     sender,
     config,
+    activeControllers,
   );
 }
 
@@ -378,10 +388,15 @@ async function sendToClaude(
   permissionBroker: ReturnType<typeof createPermissionBroker>,
   sender: ReturnType<typeof createSender>,
   config: ReturnType<typeof loadConfig>,
+  activeControllers: Map<string, AbortController>,
 ): Promise<void> {
   // Set state to processing
   session.state = 'processing';
   sessionStore.save(account.accountId, session);
+
+  // Create abort controller for this query so it can be cancelled by new messages
+  const abortController = new AbortController();
+  activeControllers.set(account.accountId, abortController);
 
   // Record user message in chat history
   sessionStore.addChatMessage(session, 'user', userText || '(图片)');
@@ -415,23 +430,43 @@ async function sendToClaude(
     // Map 'auto' to the SDK's underlying mode (use acceptEdits as base, but we override canUseTool)
     const sdkPermissionMode = isAutoPermission ? 'acceptEdits' : effectivePermissionMode;
 
-    // Track which text chunks have already been sent via onText streaming
-    const sentChunks: string[] = [];
+    // Unified buffer: text deltas and tool summaries all go here
+    let pendingBuffer = '';
+    let anySent = false;
+    let lastSendTime = 0;
+    const SEND_INTERVAL_MS = 24_000;
+
+    // Send everything in pendingBuffer. force=true ignores rate limit.
+    async function trySend(force = false): Promise<void> {
+      if (!pendingBuffer.trim()) return;
+      const now = Date.now();
+      if (!force && now - lastSendTime < SEND_INTERVAL_MS) return;
+      const toSend = pendingBuffer.trim();
+      pendingBuffer = '';
+      const chunks = splitMessage(toSend);
+      for (const chunk of chunks) {
+        lastSendTime = Date.now();
+        anySent = true;
+        await sender.sendText(fromUserId, contextToken, chunk);
+      }
+    }
 
     const queryOptions: QueryOptions = {
       prompt: userText || '请分析这张图片',
       cwd: (session.workingDirectory || config.workingDirectory).replace(/^~/, process.env.HOME || ''),
       resume: session.sdkSessionId,
       model: session.model,
+      systemPrompt: config.systemPrompt,
       permissionMode: sdkPermissionMode,
+      abortController,
       images,
-      onText: async (text: string) => {
-        // Send each assistant message block immediately as it arrives
-        const chunks = splitMessage(text);
-        for (const chunk of chunks) {
-          sentChunks.push(chunk);
-          await sender.sendText(fromUserId, contextToken, chunk);
-        }
+      onText: async (delta: string) => {
+        pendingBuffer += delta;
+        await trySend();
+      },
+      onThinking: async (summary: string) => {
+        pendingBuffer += (pendingBuffer ? '\n' : '') + summary;
+        await trySend();
       },
       onPermissionRequest: isAutoPermission
         ? async () => true  // auto-approve all tools, skip broker
@@ -476,31 +511,26 @@ async function sendToClaude(
       Object.assign(result, retryResult);
     }
 
-    // Send result back to WeChat (show generic error to user, log details internally)
-    // Prefer text over error: SDK sometimes exits with code 1 after successfully producing output
+    // Flush any remaining buffered content
+    await trySend(true);
+
+    // Send result back to WeChat
     if (result.text) {
       if (result.error) {
         logger.warn('Claude query had error but returned text, using text', { error: result.error });
       }
-      // Record assistant response in chat history
       sessionStore.addChatMessage(session, 'assistant', result.text);
-
-      // Send any chunks not already streamed via onText
-      const allChunks = splitMessage(result.text);
-      const sentSet = new Set(sentChunks);
-      const remaining = allChunks.filter(c => !sentSet.has(c));
-      for (const chunk of remaining) {
-        await sender.sendText(fromUserId, contextToken, chunk);
-      }
-
-      // If nothing was sent at all, send full text now
-      if (sentChunks.length === 0 && remaining.length === 0) {
-        await sender.sendText(fromUserId, contextToken, result.text);
+      // If nothing was streamed at all (e.g. streaming not supported), send full text now
+      if (!anySent) {
+        const chunks = splitMessage(result.text);
+        for (const chunk of chunks) {
+          await sender.sendText(fromUserId, contextToken, chunk);
+        }
       }
     } else if (result.error) {
       logger.error('Claude query error', { error: result.error });
       await sender.sendText(fromUserId, contextToken, '⚠️ Claude 处理请求时出错，请稍后重试。');
-    } else if (sentChunks.length === 0) {
+    } else if (!anySent) {
       await sender.sendText(fromUserId, contextToken, 'ℹ️ Claude 无返回内容（可能因权限被拒而终止）');
     }
 
@@ -509,13 +539,22 @@ async function sendToClaude(
     session.state = 'idle';
     sessionStore.save(account.accountId, session);
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err);
-    logger.error('Error in sendToClaude', { error: errorMsg });
-    await sender.sendText(fromUserId, contextToken, '⚠️ 处理消息时出错，请稍后重试。');
-
-    // Reset state
+    const isAbort = err instanceof Error && (err.name === 'AbortError' || err.message.includes('abort'));
+    if (isAbort) {
+      // Query was cancelled by a new incoming message — exit silently
+      logger.info('Claude query aborted by new message');
+    } else {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      logger.error('Error in sendToClaude', { error: errorMsg });
+      await sender.sendText(fromUserId, contextToken, '⚠️ 处理消息时出错，请稍后重试。');
+    }
     session.state = 'idle';
     sessionStore.save(account.accountId, session);
+  } finally {
+    // Clean up the abort controller if it's still ours
+    if (activeControllers.get(account.accountId) === abortController) {
+      activeControllers.delete(account.accountId);
+    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -434,7 +434,7 @@ async function sendToClaude(
     let pendingBuffer = '';
     let anySent = false;
     let lastSendTime = 0;
-    const SEND_INTERVAL_MS = 24_000;
+    const SEND_INTERVAL_MS = 36_000;
 
     // Send everything in pendingBuffer. force=true ignores rate limit.
     async function trySend(force = false): Promise<void> {

--- a/src/session.ts
+++ b/src/session.ts
@@ -80,6 +80,8 @@ export function createSessionStore() {
 
   function clear(accountId: string, currentSession?: Session): Session {
     const session: Session = {
+      sdkSessionId: undefined,          // explicitly clear so Object.assign removes it
+      previousSdkSessionId: undefined,
       workingDirectory: currentSession?.workingDirectory ?? process.cwd(),
       model: currentSession?.model,
       permissionMode: currentSession?.permissionMode,

--- a/src/wechat/api.ts
+++ b/src/wechat/api.ts
@@ -48,7 +48,7 @@ export class WeChatApi {
     };
   }
 
-  private async request<T>(
+  private async request<T = Record<string, unknown>>(
     path: string,
     body: unknown,
     timeoutMs: number = 15_000,
@@ -95,9 +95,24 @@ export class WeChatApi {
     );
   }
 
-  /** Send a message to a user. */
+  /** Send a message to a user. Retries up to 3 times on rate-limit (ret: -2). */
   async sendMessage(req: SendMessageReq): Promise<void> {
-    await this.request('ilink/bot/sendmessage', req);
+    const MAX_RETRIES = 3;
+    let delay = 10_000; // start with 10s backoff on rate-limit
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const res = await this.request<{ ret?: number }>('ilink/bot/sendmessage', req);
+      if ((res as any)?.ret === -2) {
+        if (attempt === MAX_RETRIES) {
+          logger.warn('sendMessage rate-limited after max retries', { attempts: MAX_RETRIES });
+          return; // give up silently rather than crash
+        }
+        logger.warn('sendMessage rate-limited (ret:-2), retrying', { attempt, delayMs: delay });
+        await new Promise(r => setTimeout(r, delay));
+        delay = Math.min(delay * 2, 60_000); // exponential backoff, cap at 60s
+        continue;
+      }
+      return;
+    }
   }
 
   /** Get a presigned upload URL for media files. */

--- a/src/wechat/cdn.ts
+++ b/src/wechat/cdn.ts
@@ -6,8 +6,7 @@ export function buildCdnDownloadUrl(encryptQueryParam: string): string {
   if (!/^[A-Za-z0-9%=&+._~\-/]+$/.test(encryptQueryParam)) {
     throw new Error('Invalid CDN query parameter');
   }
-  // URL-encode the parameter so base64 padding (=) and other special chars are safe
-  return `${CDN_BASE_URL}?${encodeURIComponent(encryptQueryParam)}`;
+  return `${CDN_BASE_URL}/download?encrypted_query_param=${encodeURIComponent(encryptQueryParam)}`;
 }
 
 export async function downloadAndDecrypt(

--- a/src/wechat/cdn.ts
+++ b/src/wechat/cdn.ts
@@ -3,10 +3,11 @@ import { logger } from "../logger.js";
 import { CDN_BASE_URL } from "./accounts.js";
 
 export function buildCdnDownloadUrl(encryptQueryParam: string): string {
-  if (!/^[A-Za-z0-9%=&+._~-]+$/.test(encryptQueryParam)) {
+  if (!/^[A-Za-z0-9%=&+._~\-/]+$/.test(encryptQueryParam)) {
     throw new Error('Invalid CDN query parameter');
   }
-  return `${CDN_BASE_URL}?${encryptQueryParam}`;
+  // URL-encode the parameter so base64 padding (=) and other special chars are safe
+  return `${CDN_BASE_URL}?${encodeURIComponent(encryptQueryParam)}`;
 }
 
 export async function downloadAndDecrypt(

--- a/src/wechat/media.ts
+++ b/src/wechat/media.ts
@@ -26,9 +26,10 @@ function getImageCdnData(imageItem: ImageItem): { aesKey: string; encryptQueryPa
   }
 
   // New format: aeskey + media.encrypt_query_param
-  if (imageItem.aeskey && imageItem.media?.encrypt_query_param) {
+  // Use media.aes_key (base64-of-hex) over aeskey (raw hex) since downloadAndDecrypt expects base64
+  if (imageItem.media?.encrypt_query_param && (imageItem.media.aes_key || imageItem.aeskey)) {
     return {
-      aesKey: imageItem.aeskey,
+      aesKey: imageItem.media.aes_key ?? imageItem.aeskey!,
       encryptQueryParam: imageItem.media.encrypt_query_param,
     };
   }

--- a/src/wechat/types.ts
+++ b/src/wechat/types.ts
@@ -40,7 +40,7 @@ export interface ImageItem {
   cdn_media?: CDNMedia;
   /** Alternative field name used by some API versions */
   aeskey?: string;
-  media?: { encrypt_query_param: string };
+  media?: { encrypt_query_param: string; aes_key?: string };
   url?: string;
   mid_size?: number;
   hd_size?: number;


### PR DESCRIPTION

  ## Summary

  本 PR 整合了一批功能增强和 bug 修复，已在个人微信环境下实测验证。

  ### 新功能
  - **实时进度推送** — 工具调用时实时显示 `🔧 Bash:`、`📖 Read:` 等摘要，用户等待期间可看到 Claude 的工作进展
  - **思考预览** — 每个思考块结束后推送最多 300 字的 `💭` 摘要（仅在使用扩展思考模型时出现）
  - `/prompt [内容]` 命令 — 设置持久化系统提示词（如"用中文回答"），全局追加到每次查询
  - `/compact` 命令 — 开启新 SDK 会话清空 token 上下文，保留本地聊天历史

  ### Bug 修复
  - **图片下载** — CDN URL 格式修正为 `/download?encrypted_query_param=`，并使用 `media.aes_key`（base64）替代顶层
  `aeskey`（原始 hex）以解决 AES 密钥长度错误
  - **消息碎片化** — `lastSendTime` 初始化为 `Date.now()`，防止首个 delta 立即触发发送（原先第一条消息只发"您"一个字）
  - **`/clear` 无效** — 显式设置 `sdkSessionId: undefined` 确保会话真正重置
  - **工作目录 `~` 展开** — 传给 SDK 前展开 tilde，避免 `spawn ENOENT`
  - **有输出时不报错** — SDK 以非零退出但有文本输出时，正确返回文本而非报错

  ### 稳定性
  - 统一 pending buffer（thinking + text 合并后限速发送，间隔 36s）
  - 中断支持：新消息到来时 abort 当前查询
  - README 双语更新

  ## Test plan

  - [ ] 发送普通文字消息，确认有工具调用进度推送
  - [ ] 发送图片，确认日志出现 `Image downloaded and decrypted`
  - [ ] 使用 `/prompt 用中文回答`，确认后续回复语言变化
  - [ ] 使用 `/clear` 后发消息，确认无上下文记忆
  - [ ] 长时间任务确认无 `ret:-2` 频率限制报错


截图：

<img width="1440" height="3200" alt="S60325-21002046_com tencent mm" src="https://github.com/user-attachments/assets/c739f990-eccc-4a50-aff5-1bf5357ca78c" />

<img width="1440" height="3200" alt="S60325-16160090_com tencent mm" src="https://github.com/user-attachments/assets/89f89207-1614-4f84-a6b2-e9a873924c61" />

<img width="1440" height="3200" alt="S60325-16161768_com tencent mm" src="https://github.com/user-attachments/assets/ea055fd0-cafa-40b5-b6ff-c75840c266ab" />
