### PR TITLE
feat: support receiving voice messages via ASR transcription

### DIFF
--- a/src/wechat/media.ts
+++ b/src/wechat/media.ts
@@ -73,9 +73,15 @@ export async function downloadImage(item: MessageItem): Promise<string | null> {
 
 /**
  * Extract text content from a message item.
- * Returns text_item.text or empty string.
+ * Handles text items and voice items (using ASR transcription).
  */
 export function extractText(item: MessageItem): string {
+  if (item.type === MessageItemType.VOICE) {
+    const voiceText = item.voice_item?.voice_text || item.voice_item?.text;
+    if (voiceText) {
+      return `[语音] ${voiceText}`;
+    }
+  }
   return item.text_item?.text ?? '';
 }
 

--- a/src/wechat/types.ts
+++ b/src/wechat/types.ts
@@ -48,7 +48,9 @@ export interface ImageItem {
 
 export interface VoiceItem {
   cdn_media: CDNMedia;
+  media?: { encrypt_query_param: string; aes_key?: string };
   voice_text?: string;
+  text?: string;
 }
 
 export interface FileItem {


### PR DESCRIPTION
## Summary

- Extract voice text from incoming WeChat voice messages using the ASR transcription provided by the iLink API
- Voice messages now appear as `[语音] <transcribed text>` and are processed by Claude like normal text input
- Handle both `voice_text` and `text` field names in `VoiceItem` (the actual iLink API returns `text`, not `voice_text`)

## Changes

- `src/wechat/media.ts`: Add voice type handling in `extractText()` to return ASR transcription with `[语音]` prefix
- `src/wechat/types.ts`: Add `text` and `media` fields to `VoiceItem` interface to match actual API response

## Test plan

- [x] Send a voice message from WeChat → Claude receives the transcribed text and replies normally
- [x] Text and image messages continue to work as before
- [x] Build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)