### PR TITLE
fix: 支持 Windows 路径的文件自动推送

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,8 +37,8 @@ const AUTO_PUSH_EXTENSIONS = new Set([
 /** Extract local file paths from Claude's response text. */
 function extractFilePathsFromText(text: string, cwd: string): string[] {
   const paths: string[] = [];
-  // Match absolute paths (macOS/Linux) and tilde paths with a file extension
-  const regex = /(?:\/(?:Users|home|tmp|var|etc)\/[^\s`'"()\[\]{}|<>]+\.\w+|~\/[^\s`'"()\[\]{}|<>]+\.\w+)/g;
+  // Match absolute paths (macOS/Linux), tilde paths, and Windows paths with a file extension
+  const regex = /(?:\/(?:Users|home|tmp|var|etc)\/[^\s`'"()\[\]{}|<>]+\.\w+|~\/[^\s`'"()\[\]{}|<>]+\.\w+|[A-Za-z]:[\\\/][^\s`'"()\[\]{}|<>]+\.\w+)/g;
   let match: RegExpExecArray | null;
   while ((match = regex.exec(text)) !== null) {
     const raw = match[0];


### PR DESCRIPTION
## 问题

`extractFilePathsFromText` 的正则表达式只匹配 macOS/Linux 绝对路径（如 `/Users/...`），导致在 Windows 上文件自动推送功能静默失败。

Windows 路径格式（如 `C:\Users\...`）完全无法被识别，所以 Claude 回复中包含的文件路径不会被自动推送。

## 修复

在正则中添加 `[A-Za-z]:[\/]` 模式，匹配 Windows 盘符路径，与现有的 Unix 和 tilde 路径并列。

**改动前：**
```typescript
const regex = /(?:\/(?:Users|home|tmp|var|etc)\/[^\s`'"()\[\]{}|<>]+\.\w+|~\/[^\s`'"()\[\]{}|<>]+\.\w+)/g;
```

**改动后：**
```typescript
const regex = /(?:\/(?:Users|home|tmp|var|etc)\/[^\s`'"()\[\]{}|<>]+\.\w+|~\/[^\s`'"()\[\]{}|<>]+\.\w+|[A-Za-z]:[\\/][^\s`'"()\[\]{}|<>]+\.\w+)/g;
```