### PR TITLE
fix: support Windows paths in auto-push file detection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,8 +37,8 @@ const AUTO_PUSH_EXTENSIONS = new Set([
 /** Extract local file paths from Claude's response text. */
 function extractFilePathsFromText(text: string, cwd: string): string[] {
   const paths: string[] = [];
-  // Match absolute paths (macOS/Linux) and tilde paths with a file extension
-  const regex = /(?:\/(?:Users|home|tmp|var|etc)\/[^\s`'"()\[\]{}|<>]+\.\w+|~\/[^\s`'"()\[\]{}|<>]+\.\w+)/g;
+  // Match absolute paths (macOS/Linux), tilde paths, and Windows paths with a file extension
+  const regex = /(?:\/(?:Users|home|tmp|var|etc)\/[^\s`'"()\[\]{}|<>]+\.\w+|~\/[^\s`'"()\[\]{}|<>]+\.\w+|[A-Za-z]:[\\/][^\s`'"()\[\]{}|<>]+\.\w+)/g;
   let match: RegExpExecArray | null;
   while ((match = regex.exec(text)) !== null) {
     const raw = match[0];


### PR DESCRIPTION
## Problem

The `extractFilePathsFromText` function only matched macOS/Linux paths (`/Users/...`, `~/...`), causing file auto-push to silently fail on Windows where paths look like `C:\Users\...`.

## Fix

Added `[A-Za-z]:[\/]` pattern to the regex to match Windows drive-letter paths alongside existing Unix and tilde paths.

### Before
```typescript
const regex = /(?:\/(?:Users|home|tmp|var|etc)\/[^\s...\.\w+|~\/[^\s...\.\w+)/g;
```

### After
```typescript
const regex = /(?:\/(?:Users|home|tmp|var|etc)\/[^\s...\.\w+|~\/[^\s...\.\w+|[A-Za-z]:[\/][^\s...\.\w+)/g;
```

## Testing

Confirmed on Windows 11: Claude outputs a path like `C:\Users\caiyu\Desktop\临时文件\舞会之后.pptx` and the file is correctly auto-pushed to WeChat.