### PR TITLE
feat: add Windows platform support (lightweight, seamless)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ npm run daemon -- logs     # 查看日志
 ## 前置条件
 
 - Node.js >= 18
-- macOS 或 Linux
+- macOS、Windows 或 Linux
 - 个人微信账号
 - 已安装 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI 并完成认证
 

--- a/README_en.md
+++ b/README_en.md
@@ -121,7 +121,7 @@ The daemon long-polls WeChat for new messages, forwards them to the local `claud
 ## Prerequisites
 
 - Node.js >= 18
-- macOS or Linux
+- macOS, Windows, or Linux
 - A personal WeChat account
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed and authenticated
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,7 +10,7 @@ description: 微信消息桥接 - 在微信中与 Claude Code 聊天。支持文
 ## 前置条件
 
 - Node.js >= 18
-- macOS（daemon 使用 launchd 管理）
+- macOS、Windows 或 Linux
 - 个人微信账号（需扫码绑定）
 - 已安装 Claude Code（`@anthropic-ai/claude-agent-sdk`）
 

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -376,6 +376,114 @@ linux_logs() {
 }
 
 # =============================================================================
+# Windows (Git Bash / MINGW) functions
+# =============================================================================
+
+windows_pid_file() {
+  echo "${DATA_DIR}/${SERVICE_NAME}.pid"
+}
+
+windows_start() {
+  local pid_file="$(windows_pid_file)"
+  local node_bin="$(command -v node 2>/dev/null || echo 'node')"
+
+  if [ -f "$pid_file" ]; then
+    local old_pid=$(cat "$pid_file" 2>/dev/null)
+    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+      echo "Already running (PID: $old_pid)"
+      exit 0
+    fi
+    rm -f "$pid_file"
+  fi
+
+  mkdir -p "$DATA_DIR/logs"
+
+  echo "Starting wechat-claude-code daemon (Windows)..."
+  nohup "$node_bin" "${PROJECT_DIR}/dist/main.js" start \
+    >> "$DATA_DIR/logs/stdout.log" \
+    2>> "$DATA_DIR/logs/stderr.log" &
+  local pid=$!
+  echo "$pid" > "$pid_file"
+  echo "Started (PID: $pid)"
+  echo "Logs: $DATA_DIR/logs/stdout.log"
+}
+
+windows_stop() {
+  local pid_file="$(windows_pid_file)"
+
+  if [ ! -f "$pid_file" ]; then
+    echo "Not running (no PID file)"
+    exit 0
+  fi
+
+  local pid=$(cat "$pid_file" 2>/dev/null)
+  if [ -z "$pid" ]; then
+    rm -f "$pid_file"
+    echo "Stopped"
+    exit 0
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    local count=0
+    while kill -0 "$pid" 2>/dev/null && [ $count -lt 10 ]; do
+      sleep 1
+      count=$((count + 1))
+    done
+    # Fallback: use taskkill if process still alive
+    if kill -0 "$pid" 2>/dev/null; then
+      taskkill //F //PID "$pid" 2>/dev/null || true
+    fi
+    echo "Stopped (PID: $pid)"
+  else
+    echo "Process not running (cleaning up PID file)"
+  fi
+
+  rm -f "$pid_file"
+}
+
+windows_status() {
+  local pid_file="$(windows_pid_file)"
+
+  if [ ! -f "$pid_file" ]; then
+    echo "Not running"
+    exit 0
+  fi
+
+  local pid=$(cat "$pid_file" 2>/dev/null)
+  if [ -z "$pid" ]; then
+    echo "Not running (invalid PID file)"
+    exit 0
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "Running (PID: $pid)"
+  else
+    echo "Not running (stale PID file)"
+  fi
+}
+
+windows_logs() {
+  local log_dir="${DATA_DIR}/logs"
+  if [ -d "$log_dir" ]; then
+    local latest=$(ls -t "${log_dir}"/bridge-*.log 2>/dev/null | head -1)
+    if [ -n "$latest" ]; then
+      tail -100 "$latest"
+    else
+      for f in "${log_dir}"/stdout.log "${log_dir}"/stderr.log; do
+        if [ -f "$f" ]; then
+          echo "=== $(basename "$f") ==="
+          tail -50 "$f"
+          echo ""
+        fi
+      done
+    fi
+  else
+    echo "No logs found"
+  fi
+}
+
+# =============================================================================
 # Main dispatcher
 # =============================================================================
 
@@ -411,9 +519,23 @@ main() {
           ;;
       esac
       ;;
+    MINGW*|MSYS*|CYGWIN*)
+      case "$command" in
+        start)   windows_start ;;
+        stop)    windows_stop ;;
+        restart) windows_stop; sleep 1; windows_start ;;
+        status)  windows_status ;;
+        logs)    windows_logs ;;
+        *)
+          echo "Usage: daemon.sh {start|stop|restart|status|logs}"
+          echo "Platform: Windows (Git Bash)"
+          exit 1
+          ;;
+      esac
+      ;;
     *)
       echo "Error: Unsupported platform '$OS_TYPE'"
-      echo "Supported platforms: macOS (Darwin), Linux"
+      echo "Supported platforms: macOS (Darwin), Linux, Windows (MINGW/MSYS)"
       exit 1
       ;;
   esac

--- a/src/tools/visualize-logs.ts
+++ b/src/tools/visualize-logs.ts
@@ -721,7 +721,12 @@ function main() {
     writeFileSync(output, html, 'utf-8');
     console.log(`Written to: ${output}`);
     if (open) {
-      execSync(`open "${output}"`);
+      const cmd = process.platform === 'win32'
+        ? `cmd /c start "" "${output}"`
+        : process.platform === 'darwin'
+          ? `open "${output}"`
+          : `xdg-open "${output}"`;
+      execSync(cmd);
     }
   } else {
     process.stdout.write(html);

--- a/src/wechat/send.ts
+++ b/src/wechat/send.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { WeChatApi } from './api.js';
 import { MessageItemType, MessageType, MessageState, TypingStatus, type MessageItem, type OutboundMessage } from './types.js';
@@ -115,7 +116,7 @@ export function createSender(api: WeChatApi, botAccountId: string) {
   }
 
   async function sendFile(toUserId: string, contextToken: string, filePath: string): Promise<void> {
-    const resolved = resolve(filePath.replace(/^~/, process.env.HOME || ''));
+    const resolved = resolve(filePath.replace(/^~/, homedir()));
     if (!existsSync(resolved)) {
       await sendText(toUserId, contextToken, `文件不存在: ${resolved}`);
       return;


### PR DESCRIPTION
## 概述

为 wechat-claude-code 添加 Windows (Git Bash) 支持，使用户可以在 Windows 上使用与 macOS/Linux 完全一致的命令管理 daemon。

## 改动内容

### 1. `scripts/daemon.sh` — 新增 Windows (MINGW/MSYS/CYGWIN) 分支
- 新增 `windows_start`、`windows_stop`、`windows_status`、`windows_logs` 四个函数
- 使用 PID 文件 + `nohup` 后台运行（Git Bash 环境下均可用）
- `taskkill //F //PID` 作为强制停止的兜底方案
- 统一入口：所有平台均使用 `npm run daemon -- {start|stop|status|logs}`

### 2. `src/wechat/send.ts` — 修复 `homedir()` 兼容性
- `process.env.HOME` 在 Windows 上为空，改用 `homedir()` from `node:os`

### 3. `src/tools/visualize-logs.ts` — 跨平台文件打开
- macOS: `open`，Windows: `cmd /c start`，Linux: `xdg-open`

### 4. 文档更新
- `README.md`、`README_en.md`、`SKILL.md` 前置条件更新为 macOS、Windows 或 Linux

## 设计特点

- **轻量化**：仅修改 6 个文件，新增约 110 行，不新增任何文件
- **无缝衔接**：统一入口 `npm run daemon -- start`，Windows 用户无需学习新命令
- **零破坏**：macOS/Linux 的所有逻辑完全未动，不影响现有用户

## 对比其他 Windows 支持方案

| | 本 PR | PR #24 (PowerShell) | PR #26 (Node.js) |
|---|---|---|---|
| 统一入口 | ✅ | ❌ 需用 `daemon:ps` | ✅ |
| 新增文件 | 0 | 1 (daemon.ps1) | 1 (daemon.js) |
| 改动量 | ~130 行 | ~120 行 | ~500 行 |
| 源码 bug 修复 | ✅ | ❌ | ✅ |
| macOS/Linux 影响 | 零 | 零 | 替换 daemon 入口 |

## 测试

已在 Windows 11 (Git Bash/MINGW64) 上验证：
- ✅ `npm run build` 编译通过
- ✅ `npm run daemon -- start` 启动成功
- ✅ `npm run daemon -- status` 状态检测正确
- ✅ `npm run daemon -- stop` 停止成功
- ✅ `npm run daemon -- logs` 日志输出正常