### PR TITLE
fix: idle 时 /stop 不再误报「未找到 skill」

### DIFF
--- a/src/commands/handlers.ts
+++ b/src/commands/handlers.ts
@@ -63,6 +63,19 @@ export function handleClear(ctx: CommandContext): CommandResult {
   return { reply: '✅ 会话已清除，下次消息将开始新会话。', handled: true };
 }
 
+/**
+ * /stop 空闲时的反馈。
+ * 处理中的 /stop 由 main.ts 的 handlePriorityCommand 提前拦截（abort + 清空队列），
+ * 不会走到这里；走到这里说明当前没有正在跑的任务。
+ */
+export function handleStop(ctx: CommandContext): CommandResult {
+  if (ctx.session.state === 'processing') {
+    // 理论上不可达：留作防御，避免出现"未找到 skill"的误导提示
+    return { reply: '⏹ 正在停止当前任务…', handled: true };
+  }
+  return { reply: 'ℹ️ 当前没有正在进行的任务。', handled: true };
+}
+
 export function handleCwd(ctx: CommandContext, args: string): CommandResult {
   if (!args) {
     return { reply: `当前工作目录: ${ctx.session.workingDirectory}\n用法: /cwd <路径>`, handled: true };

--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -1,7 +1,7 @@
 import type { Session } from '../session.js';
 import { findSkill } from '../claude/skill-scanner.js';
 import { logger } from '../logger.js';
-import { handleHelp, handleClear, handleCwd, handleModel, handleStatus, handleSkills, handleHistory, handleReset, handleCompact, handleUndo, handleVersion, handlePrompt, handleSend, handleUnknown } from './handlers.js';
+import { handleHelp, handleClear, handleStop, handleCwd, handleModel, handleStatus, handleSkills, handleHistory, handleReset, handleCompact, handleUndo, handleVersion, handlePrompt, handleSend, handleUnknown } from './handlers.js';
 
 export interface CommandContext {
   accountId: string;
@@ -48,6 +48,8 @@ export function routeCommand(ctx: CommandContext): CommandResult {
       return handleHelp(args);
     case 'clear':
       return handleClear(ctx);
+    case 'stop':
+      return handleStop(ctx);
     case 'reset':
       return handleReset(ctx);
     case 'cwd':


### PR DESCRIPTION
## 问题
空闲（idle）状态下发送 `/stop`，命令会落到 `handleUnknown`，回复「未找到 skill: stop」，让用户误以为该命令不存在。

根因：`/stop` 只在 `main.ts` 的 `handlePriorityCommand` 里处理，且要求 `session.state === 'processing'`；`router.ts` 的 switch 中没有 `stop` 这个 case，于是 idle 时走到了 default 分支。

## 改动
- 新增 `handleStop`：空闲时友好提示「当前没有正在进行的任务」
- `router.ts` 增加 `stop` case 分发
- 处理中的 `/stop` 仍由 `handlePriorityCommand` 优先拦截 abort + 清空队列，行为不变

## 验证
- `npm run build`（tsc）通过
- 运行时验证 `routeCommand`：idle → 「当前没有正在进行的任务」；processing → 「正在停止当前任务…」