### PR TITLE
feat: 处理任务时给排队消息一个反馈

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -270,6 +270,8 @@ async function runDaemon(): Promise<void> {
   // -- Message queue for serial processing --
   const messageQueue: WeixinMessage[] = [];
   let processingQueue = false;
+  // 一波忙碌期内只发一次排队提示，避免用户连发消息时被刷屏
+  let queueNoticeSent = false;
 
   async function drainQueue(): Promise<void> {
     if (processingQueue) return;
@@ -279,6 +281,7 @@ async function runDaemon(): Promise<void> {
       await handleMessage(msg, account!, session, sessionStore, sender, config, sharedCtx, activeControllers, messageQueue);
     }
     processingQueue = false;
+    queueNoticeSent = false; // 队列已清空，下一波忙碌可再次提示
   }
 
   // -- Wire the monitor callbacks --
@@ -305,6 +308,16 @@ async function runDaemon(): Promise<void> {
   const callbacks: MonitorCallbacks = {
     onMessage: async (msg: WeixinMessage) => {
       if (handlePriorityCommand(msg)) return;
+      // 已有任务在处理时，新消息会进队列等待——立刻给一个排队反馈，
+      // 避免用户对着空白聊天框干等、误以为消息丢了。一波忙碌期只提示一次。
+      if (processingQueue && !queueNoticeSent && msg.message_type === MessageType.USER && msg.from_user_id) {
+        queueNoticeSent = true;
+        sender.sendText(
+          msg.from_user_id,
+          msg.context_token ?? '',
+          '⏳ 正在处理上一条消息，你后面发的我都收到了，会处理完依次回复。',
+        ).catch(() => {});
+      }
       messageQueue.push(msg);
       drainQueue();
     },


### PR DESCRIPTION
## 问题
用户在 Claude 处理任务期间发的消息，会进入串行队列等待当前任务整个跑完才被处理；在此期间**没有任何反馈**。用户对着空白聊天框干等，容易误以为消息丢了或机器人挂了。

## 改动
- `onMessage` 入队时，若已有任务在处理（`processingQueue`），立刻回一句排队提示：「⏳ 正在处理上一条消息，你后面发的我都收到了，会处理完依次回复。」
- 一波忙碌期内只提示一次（`queueNoticeSent` 标志），避免用户连发消息时被刷屏
- `drainQueue` 清空队列后复位标志，下一波忙碌可再次提示
- 仅对用户消息（`MessageType.USER`）提示；`/stop`、`/clear` 优先命令的即时处理不受影响

## 验证
- `npm run build`（tsc）通过
- 复刻队列状态机的时序模拟：忙时仅提示一次、非用户消息不提示、队列清空复位后下一波能再次提示 —— 全部符合预期