### PR TITLE
feat: 首次交互推送欢迎/引导消息

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,8 @@ export interface Config {
   workingDirectory: string;
   model?: string;
   systemPrompt?: string;
+  /** 是否已向用户推送过首次欢迎/引导消息（全局只发一次） */
+  welcomed?: boolean;
 }
 
 const CONFIG_DIR = join(homedir(), ".wechat-claude-code");
@@ -24,6 +26,7 @@ export function loadConfig(): Config {
       workingDirectory: parsed.workingDirectory || DEFAULT_CONFIG.workingDirectory,
       model: parsed.model,
       systemPrompt: parsed.systemPrompt,
+      welcomed: parsed.welcomed,
     };
     mkdirSync(config.workingDirectory, { recursive: true });
     return config;
@@ -36,11 +39,12 @@ export function loadConfig(): Config {
 
 export function saveConfig(config: Config): void {
   mkdirSync(CONFIG_DIR, { recursive: true });
-  const data: Record<string, string> = {
+  const data: Record<string, string | boolean> = {
     workingDirectory: config.workingDirectory,
   };
   if (config.model) data.model = config.model;
   if (config.systemPrompt) data.systemPrompt = config.systemPrompt;
+  if (config.welcomed) data.welcomed = true;
   writeFileSync(CONFIG_PATH, JSON.stringify(data, null, 2) + "\n", "utf-8");
   if (process.platform !== "win32") {
     chmodSync(CONFIG_PATH, 0o600);

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,16 @@ import { MessageType, type WeixinMessage } from './wechat/types.js';
 
 const MAX_MESSAGE_LENGTH = 4000;
 
+const WELCOME_TEXT = `👋 你好！我是接在你电脑上的 Claude Code。直接在这里发消息，就能让我帮你处理任务——读写文件、跑命令、写代码、分析图片和文档都行。
+
+常用命令：
+/help    查看全部命令
+/status  查看当前会话状态
+/clear   清空上下文、开始新对话
+/stop    停止正在执行的任务
+
+支持文字、语音、图片、文件，发一条试试看吧。`;
+
 // Extensions eligible for auto-push when detected in Claude's response
 const AUTO_PUSH_EXTENSIONS = new Set([
   '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.ico',
@@ -361,6 +371,13 @@ async function handleMessage(
   const userText = extractTextFromItems(msg.item_list);
   const imageItem = extractFirstImageUrl(msg.item_list);
   const fileItem = extractFirstFileItem(msg.item_list);
+
+  // 首次交互：推送一次欢迎/引导，避免新用户面对空白聊天框、不知道能干啥
+  if (!config.welcomed) {
+    config.welcomed = true;
+    saveConfig(config);
+    await sender.sendText(fromUserId, contextToken, WELCOME_TEXT);
+  }
 
   // Drop non-command messages while processing (priority commands already handled upstream)
   if (session.state === 'processing' && !userText.startsWith('/')) {


### PR DESCRIPTION
## 问题
新用户扫码绑定后，微信里多出一个「好友」，但对面一片空白——不知道能干啥、有哪些命令，缺少引导。

## 改动
- 首次收到用户消息时，先推送一条欢迎语 + 常用命令引导（`/help`、`/status`、`/clear`、`/stop`）
- 用 `config.welcomed` 持久化标志，**全局只发一次**
- 标志放在 `config`（而非 `session`），因此 `/clear`、`/reset` 不会让欢迎语重复出现

## 验证
- `npm run build`（tsc）通过
- 隔离 `HOME` 验证 `welcomed` 持久化往返：首次为 `undefined`（会触发）→ 保存后为 `true`（不再触发），且 `workingDirectory` 等其他字段不受影响