### PR TITLE
fix: 图片下载失败时不再误导 Claude

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -478,6 +478,18 @@ async function sendToClaude(
       }
     }
 
+    // 图片下载/解析失败：明确告知用户，不要用「请分析这张图片」让 Claude 对着不存在的图瞎猜
+    if (imageItem && !images) {
+      if (userText) {
+        await sender.sendText(fromUserId, contextToken, '⚠️ 图片接收失败，我先按你的文字内容处理；图片可以重发一次。');
+      } else {
+        await sender.sendText(fromUserId, contextToken, '⚠️ 图片接收失败，请重新发送一次。');
+        session.state = 'idle';
+        sessionStore.save(account.accountId, session);
+        return;
+      }
+    }
+
     // Download file if present
     let prompt = userText || '请分析这张图片';
     if (fileItem) {


### PR DESCRIPTION
## 问题
微信图片下载/解析失败后 `images` 为空，但 prompt 仍然默认成「请分析这张图片」，结果让 Claude 对着一张**不存在的图**瞎猜，给出莫名其妙的回答。

## 改动
在图片下载块之后增加失败处理：
- **图片失败 + 有文字**：提示「图片接收失败，我先按你的文字内容处理；图片可以重发一次」，继续用文字调用 Claude
- **图片失败 + 无文字**：提示「图片接收失败，请重新发送一次」，恢复 `idle` 状态并直接退出，不调用 Claude

## 验证
- `npm run build`（tsc）通过
- 模拟四种输入的分支决策：图片成功 / 失败+有文字 / 失败+无文字 / 无图片+有文字 —— 路径全部符合预期