### PR TITLE
fix: /cwd 切换工作目录前校验路径存在

### DIFF
--- a/src/commands/handlers.ts
+++ b/src/commands/handlers.ts
@@ -67,8 +67,17 @@ export function handleCwd(ctx: CommandContext, args: string): CommandResult {
   if (!args) {
     return { reply: `当前工作目录: ${ctx.session.workingDirectory}\n用法: /cwd <路径>`, handled: true };
   }
-  ctx.updateSession({ workingDirectory: args });
-  return { reply: `✅ 工作目录已切换为: ${args}`, handled: true };
+  // 展开 ~ 并解析为绝对路径（相对路径基于当前工作目录），切换前校验目录确实存在
+  const expanded = args.replace(/^~/, homedir());
+  const resolved = expanded.startsWith('/') ? expanded : resolve(ctx.session.workingDirectory, expanded);
+  if (!existsSync(resolved)) {
+    return { reply: `目录不存在: ${resolved}\n请检查路径后重试。`, handled: true };
+  }
+  if (!statSync(resolved).isDirectory()) {
+    return { reply: `这不是一个目录: ${resolved}`, handled: true };
+  }
+  ctx.updateSession({ workingDirectory: resolved });
+  return { reply: `✅ 工作目录已切换为: ${resolved}`, handled: true };
 }
 
 export function handleModel(ctx: CommandContext, args: string): CommandResult {

--- a/src/commands/handlers.ts
+++ b/src/commands/handlers.ts
@@ -64,11 +64,13 @@ export function handleClear(ctx: CommandContext): CommandResult {
 }
 
 export function handleCwd(ctx: CommandContext, args: string): CommandResult {
-  if (!args) {
+  // 清理首尾的反引号/引号/空格：手机输入法或 markdown 代码格式常给路径自动加上这些
+  const cleaned = args.trim().replace(/^[`'"\s]+|[`'"\s]+$/g, '');
+  if (!cleaned) {
     return { reply: `当前工作目录: ${ctx.session.workingDirectory}\n用法: /cwd <路径>`, handled: true };
   }
   // 展开 ~ 并解析为绝对路径（相对路径基于当前工作目录），切换前校验目录确实存在
-  const expanded = args.replace(/^~/, homedir());
+  const expanded = cleaned.replace(/^~/, homedir());
   const resolved = expanded.startsWith('/') ? expanded : resolve(ctx.session.workingDirectory, expanded);
   if (!existsSync(resolved)) {
     return { reply: `目录不存在: ${resolved}\n请检查路径后重试。`, handled: true };


### PR DESCRIPTION
## 问题
`/cwd` 原来直接把用户输入写入 session，**不做任何校验**。一旦路径输错，下次对话时 `claude` 会在一个不存在的 `cwd` 里 spawn，导致失败，且错误信息隐晦、难以排查。（对比之下 `/send` 已经有 `existsSync` 校验，`/cwd` 缺。）

## 改动
- 展开 `~`、把相对路径解析为绝对路径（基于当前工作目录）
- 切换前校验目标**存在**且**确实是目录**，否则提示并拒绝切换
- 存储解析后的绝对路径，与 `/send` 的校验风格保持一致

## 验证
- `npm run build`（tsc）通过
- 独立验证 `handleCwd` 四种情况：存在目录→切换、不存在→拒绝、是文件→拒绝、空参→显示当前 —— 全部符合预期