### PR TITLE
feat: add multi-instance Git approval workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -79,7 +79,13 @@ Windows 原生后台管理使用 PowerShell：
 ```powershell
 npm run daemon:windows -- start -Instance default
 npm run daemon:windows -- status -Instance default
+
+# 注册“当前用户登录时启动”的计划任务，并立即切换为受管运行
+npm run daemon:windows -- enable-startup -Instance default
+npm run daemon:windows -- startup-status -Instance default
 ```
+
+`enable-startup` 会固定当前项目路径、数据目录和 Node 路径。Windows 用户登录后自动启动；Node 进程异常退出时，常驻监督器会在一分钟后重启，任务计划程序也会在监督器自身失败时恢复。项目或 Node 路径改变后应重新运行一次该命令。用 `disable-startup` 删除计划任务（当前实例会继续以普通后台模式运行）。
 
 ## 多微信账号与 Git 审批
 
@@ -103,10 +109,15 @@ npm run daemon -- start --instance writer-b
 Windows：
 
 ```powershell
-npm run daemon:windows -- start -Instance admin
-npm run daemon:windows -- start -Instance writer-a
-npm run daemon:windows -- start -Instance writer-b
+npm run daemon:windows -- enable-startup -Instance admin
+npm run daemon:windows -- enable-startup -Instance writer-a
+npm run daemon:windows -- enable-startup -Instance writer-b
+
+npm run daemon:windows -- startup-status -Instance admin
+npm run daemon:windows -- status -Instance writer-a
 ```
+
+启用后，原有的 `start`、`stop`、`restart` 会自动通过对应计划任务管理实例。`stop` 只停止当前运行，实例仍会在下次登录时自动启动；需要永久取消时使用 `disable-startup`。
 
 查看已配置实例：
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | **电脑手机体验一致** | 手机端和电脑端 Claude Code 行为完全相同——同样的编排逻辑、同样的输出效果。不是两个割裂的 AI。 |
 | **文件双向收发** | 发图片、Word、PDF 给 Claude 分析；Claude 生成的文件也会直接推送到微信，不用回到电脑前查看。 |
 | **超时安抚** | 任务超过 5 分钟没响应？它会自动发一条消息告诉你还在干，不会让你对着空白聊天框干等。 |
+| **多实例与 Git 审批** | 一份项目可绑定多个微信账号；普通实例只读并提交请求，唯一管理员审批后才执行修改。 |
 
 ## 快速安装
 
@@ -73,6 +74,58 @@ npm run daemon -- restart  # 重启服务（更新代码后使用）
 npm run daemon -- logs     # 查看日志
 ```
 
+Windows 原生后台管理使用 PowerShell：
+
+```powershell
+npm run daemon:windows -- start -Instance default
+npm run daemon:windows -- status -Instance default
+```
+
+## 多微信账号与 Git 审批
+
+每个命名实例拥有独立的微信凭据、配置、session、同步游标和日志。同一份项目源码可以同时运行多个实例。
+实例名必须以字母或数字开头，只能包含字母、数字、点、下划线和连字符，最长 64 位。
+
+```bash
+# 第一个实例设为唯一管理员
+npm run setup -- --instance admin --role admin
+
+# 其它微信号设为普通请求实例（每条命令分别扫码）
+npm run setup -- --instance writer-a --role requester
+npm run setup -- --instance writer-b --role requester
+
+# macOS / Linux
+npm run daemon -- start --instance admin
+npm run daemon -- start --instance writer-a
+npm run daemon -- start --instance writer-b
+```
+
+Windows：
+
+```powershell
+npm run daemon:windows -- start -Instance admin
+npm run daemon:windows -- start -Instance writer-a
+npm run daemon:windows -- start -Instance writer-b
+```
+
+查看已配置实例：
+
+```bash
+npm run instances
+```
+
+权限规则：
+
+- 系统只允许配置一个 `admin` 实例。
+- `requester` 的 Claude 使用 `plan` 权限模式和 `Read,Grep,Glob` 工具，禁用写文件、Shell、hooks、MCP 与插件。
+- 普通实例通过 `/request <修改需求>` 将请求写入本地 Git 审批账本。
+- 管理员通过 `/requests` 查看，通过 `/approve <请求号>` 或 `/reject <请求号>` 处理。
+- 审批执行因重启或崩溃中断时，管理员用 `/recover <请求号>` 将残留修改提交到提案分支并收口。
+- 批准时会从目标仓库创建 `wcc/request/<请求号>` 分支和隔离 worktree。Claude 完成后自动提交；目标分支未变化时自动快进合并。
+- 管理员直接执行的修改也会自动提交。目标目录不是 Git 仓库或已有未提交改动时，任务自动降级为只读。
+
+> 这是应用级权限边界。所有实例若以同一个操作系统用户运行，该用户仍可在程序外修改配置或文件。需要抵抗恶意进程时，应再使用独立 Windows 用户、容器或虚拟机隔离。
+
 ## 微信端命令
 
 直接在微信聊天中发送即可：
@@ -91,6 +144,11 @@ npm run daemon -- logs     # 查看日志
 | `/compact` | 压缩上下文，开始新 CLI 会话 |
 | `/reset` | 完全重置（包括工作目录等设置） |
 | `/undo [数量]` | 撤销最近几条对话 |
+| `/request <需求>` | 提交 Git 修改请求 |
+| `/requests [all]` | 查看修改请求（仅管理员） |
+| `/approve <请求号>` | 批准、执行并提交修改（仅管理员） |
+| `/reject <请求号> [原因]` | 拒绝修改请求（仅管理员） |
+| `/recover <请求号>` | 保存并收口中断的审批（仅管理员） |
 | `/<skill> [参数]` | 触发任意已安装的 Skill |
 
 ## 工作原理
@@ -110,7 +168,7 @@ npm run daemon -- logs     # 查看日志
 ## 前置条件
 
 - Node.js >= 18
-- macOS 或 Linux
+- Windows、macOS 或 Linux（Windows 使用 `daemon:windows`）
 - 个人微信账号
 - 已安装 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI 并完成认证
 
@@ -122,10 +180,11 @@ npm run daemon -- logs     # 查看日志
 
 ```
 ~/.wechat-claude-code/
-├── accounts/       # 微信账号凭证
-├── config.json     # 全局配置
-├── sessions/       # 会话数据
-└── logs/           # 运行日志（每日轮转，保留 30 天）
+├── accounts/                    # default 实例凭据（向后兼容）
+├── instances/<实例名>/          # 命名实例的凭据、配置、session、游标和日志
+├── approval-ledger/.git/        # Git 审批账本
+├── approval-ledger/requests/    # 修改请求及状态
+└── approval-worktrees/          # 审批执行时的临时隔离 worktree
 ```
 
 ## License

--- a/README_en.md
+++ b/README_en.md
@@ -24,6 +24,7 @@ Scan a QR code to bind your WeChat, and a new "friend" appears in your contacts.
 | **Consistent experience** | Mobile and desktop Claude Code behave identically — same orchestration, same output. Not two disconnected AIs. |
 | **Two-way files** | Send images, Word docs, PDFs for Claude to analyze. Files Claude generates get pushed directly to WeChat — no need to go back to your computer. |
 | **Timeout reassurance** | Task taking longer than 5 minutes? You'll get an automatic message letting you know it's still working. |
+| **Multi-instance Git approval** | Bind several WeChat accounts to one installation. Requesters stay read-only; one admin approves all changes. |
 
 ---
 
@@ -76,6 +77,51 @@ npm run daemon -- restart  # Restart (after code updates)
 npm run daemon -- logs     # View recent logs
 ```
 
+Native Windows background management uses PowerShell:
+
+```powershell
+npm run daemon:windows -- start -Instance default
+npm run daemon:windows -- status -Instance default
+```
+
+## Multiple WeChat Accounts and Git Approval
+
+Each named instance has isolated credentials, config, sessions, sync cursor, and logs. One source installation can run all instances.
+Instance names must start with a letter or digit, may contain letters, digits, dots, underscores, and hyphens, and are limited to 64 characters.
+
+```bash
+npm run setup -- --instance admin --role admin
+npm run setup -- --instance writer-a --role requester
+npm run setup -- --instance writer-b --role requester
+
+# macOS / Linux
+npm run daemon -- start --instance admin
+npm run daemon -- start --instance writer-a
+npm run daemon -- start --instance writer-b
+```
+
+On Windows:
+
+```powershell
+npm run daemon:windows -- start -Instance admin
+npm run daemon:windows -- start -Instance writer-a
+npm run daemon:windows -- start -Instance writer-b
+```
+
+List configured instances with `npm run instances`.
+
+Governance rules:
+
+- Only one `admin` instance may be configured.
+- A `requester` Claude process runs in `plan` mode with only `Read,Grep,Glob`; write tools, shell, hooks, MCP servers, and plugins are disabled.
+- `/request <change>` commits a request to the local Git approval ledger.
+- The admin uses `/requests`, `/approve <id>`, and `/reject <id>`.
+- If an approval is interrupted by a restart or crash, `/recover <id>` commits the remaining work to its proposal branch and closes it as failed.
+- Approval creates an isolated `wcc/request/<id>` branch and worktree. Changes are committed automatically and fast-forwarded only if the target branch has not moved.
+- Direct admin changes are also committed automatically. A non-Git or dirty workspace is downgraded to read-only.
+
+> This is an application-level boundary. For protection against a malicious process running as the same OS user, add separate Windows users, containers, or VM isolation.
+
 ---
 
 ## WeChat Commands
@@ -96,6 +142,11 @@ Send these directly in the WeChat chat:
 | `/compact` | Compact context, start a new CLI session |
 | `/reset` | Full reset including working directory |
 | `/undo [n]` | Remove last N messages from history |
+| `/request <change>` | Submit a Git change request |
+| `/requests [all]` | List requests (admin only) |
+| `/approve <id>` | Approve, execute, and commit (admin only) |
+| `/reject <id> [reason]` | Reject a request (admin only) |
+| `/recover <id>` | Save and close an interrupted approval (admin only) |
 | `/<skill> [args]` | Trigger any installed Skill |
 
 ---
@@ -121,7 +172,7 @@ The daemon long-polls WeChat for new messages, forwards them to the local `claud
 ## Prerequisites
 
 - Node.js >= 18
-- macOS or Linux
+- Windows, macOS, or Linux (use `daemon:windows` on Windows)
 - A personal WeChat account
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed and authenticated
 
@@ -133,10 +184,11 @@ All data is stored in `~/.wechat-claude-code/`:
 
 ```
 ~/.wechat-claude-code/
-├── accounts/       # WeChat account credentials
-├── config.json     # Global config
-├── sessions/       # Session data
-└── logs/           # Rotating logs (daily, 30-day retention)
+├── accounts/                    # Legacy default-instance credentials
+├── instances/<instance>/        # Isolated credentials, config, sessions, cursor, and logs
+├── approval-ledger/.git/        # Git approval ledger
+├── approval-ledger/requests/    # Requests and review status
+└── approval-worktrees/          # Temporary isolated approval worktrees
 ```
 
 ## License

--- a/README_en.md
+++ b/README_en.md
@@ -82,7 +82,13 @@ Native Windows background management uses PowerShell:
 ```powershell
 npm run daemon:windows -- start -Instance default
 npm run daemon:windows -- status -Instance default
+
+# Register an at-logon task and switch immediately to managed execution
+npm run daemon:windows -- enable-startup -Instance default
+npm run daemon:windows -- startup-status -Instance default
 ```
+
+`enable-startup` pins the current project, data-directory, and Node paths. The task starts after this Windows user logs on. A resident supervisor restarts the Node child one minute after an unexpected exit, while Task Scheduler also recovers the supervisor itself. Run it again after moving the project or Node installation. `disable-startup` removes the task while keeping the instance running in ordinary background mode.
 
 ## Multiple WeChat Accounts and Git Approval
 
@@ -103,10 +109,15 @@ npm run daemon -- start --instance writer-b
 On Windows:
 
 ```powershell
-npm run daemon:windows -- start -Instance admin
-npm run daemon:windows -- start -Instance writer-a
-npm run daemon:windows -- start -Instance writer-b
+npm run daemon:windows -- enable-startup -Instance admin
+npm run daemon:windows -- enable-startup -Instance writer-a
+npm run daemon:windows -- enable-startup -Instance writer-b
+
+npm run daemon:windows -- startup-status -Instance admin
+npm run daemon:windows -- status -Instance writer-a
 ```
+
+After autostart is enabled, `start`, `stop`, and `restart` automatically manage the corresponding scheduled task. `stop` only stops the current run, so the instance starts again at the next logon; use `disable-startup` to remove autostart permanently.
 
 List configured instances with `npm run instances`.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -127,7 +127,7 @@ cd ~/.claude/skills/wechat-claude-code && npm run daemon -- status
 | status | `npm run daemon -- status` | 查看运行状态 |
 | logs | `npm run daemon -- logs` | 查看最近日志（tail -100） |
 
-Windows 使用 `npm run daemon:windows -- <命令> -Instance <实例名>`。
+Windows 使用 `npm run daemon:windows -- <命令> -Instance <实例名>`。支持 `enable-startup` 注册当前用户登录自启动、`startup-status` 检查计划任务、`disable-startup` 删除自启动；启用后 `start/stop/restart` 会管理对应计划任务。
 
 ## 多实例与审批
 
@@ -144,6 +144,16 @@ npm run setup -- --instance worker-a --role requester
 npm run daemon -- start --instance admin
 npm run daemon -- status --instance worker-a
 ```
+
+Windows 推荐让每个实例注册独立的登录自启动任务：
+
+```powershell
+npm run daemon:windows -- enable-startup -Instance admin
+npm run daemon:windows -- enable-startup -Instance worker-a
+npm run daemon:windows -- startup-status -Instance admin
+```
+
+任务固定注册时的项目、数据目录和 Node 路径，在当前 Windows 用户登录后启动。常驻监督器会在 Node 异常退出一分钟后重启子进程，任务计划程序则负责恢复监督器自身。路径改变后重新运行 `enable-startup`。
 
 普通实例只能只读访问 Claude，并使用 `/request <需求>` 提交 Git 修改请求。唯一管理员实例使用 `/requests`、`/approve <请求号>`、`/reject <请求号>` 审批；中断的执行使用 `/recover <请求号>` 收口。目标仓库必须是干净的 Git 工作树。
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,7 +10,7 @@ description: 微信消息桥接 - 在微信中与 Claude Code 聊天。支持文
 ## 前置条件
 
 - Node.js >= 18
-- macOS（daemon 使用 launchd 管理）
+- Windows、macOS 或 Linux
 - 个人微信账号（需扫码绑定）
 - 已安装 Claude Code（`@anthropic-ai/claude-agent-sdk`）
 
@@ -65,7 +65,7 @@ cd ~/.claude/skills/wechat-claude-code && test -d node_modules && echo "deps_ok"
 ### 第 2 步：检查是否已绑定微信账号
 
 ```bash
-ls ~/.wechat-claude-code/accounts/*.json 2>/dev/null | head -1
+find ~/.wechat-claude-code -path '*/accounts/*.json' -type f 2>/dev/null | head -1
 ```
 
 - 如果没有账号文件：提示用户需要先执行 setup 扫码绑定，询问是否现在执行。
@@ -76,6 +76,8 @@ ls ~/.wechat-claude-code/accounts/*.json 2>/dev/null | head -1
 ```bash
 cd ~/.claude/skills/wechat-claude-code && npm run daemon -- status
 ```
+
+如果用户指定了命名实例，使用 `npm run daemon -- status --instance <实例名>`；Windows 使用 `npm run daemon:windows -- status -Instance <实例名>`。
 
 ### 第 4 步：根据状态展示信息
 
@@ -125,15 +127,35 @@ cd ~/.claude/skills/wechat-claude-code && npm run daemon -- status
 | status | `npm run daemon -- status` | 查看运行状态 |
 | logs | `npm run daemon -- logs` | 查看最近日志（tail -100） |
 
+Windows 使用 `npm run daemon:windows -- <命令> -Instance <实例名>`。
+
+## 多实例与审批
+
+创建一个管理员实例和任意数量的普通实例：
+
+```bash
+npm run setup -- --instance admin --role admin
+npm run setup -- --instance worker-a --role requester
+```
+
+管理命名实例时始终传入实例名：
+
+```bash
+npm run daemon -- start --instance admin
+npm run daemon -- status --instance worker-a
+```
+
+普通实例只能只读访问 Claude，并使用 `/request <需求>` 提交 Git 修改请求。唯一管理员实例使用 `/requests`、`/approve <请求号>`、`/reject <请求号>` 审批；中断的执行使用 `/recover <请求号>` 收口。目标仓库必须是干净的 Git 工作树。
+
 ## 数据目录
 
 所有数据存储在 `~/.wechat-claude-code/`：
 
 ```
 ~/.wechat-claude-code/
-├── accounts/       # 绑定的微信账号数据（每个账号一个 JSON）
-├── config.env      # 全局配置（工作目录、模型、系统提示词）
-├── sessions/       # 会话数据（每个账号一个 JSON）
-├── get_updates_buf # 消息轮询同步缓冲
-└── logs/           # 运行日志（每日轮转，保留 30 天）
+├── accounts/                    # default 实例（向后兼容）
+├── instances/<实例名>/          # 实例隔离数据
+├── approval-ledger/.git/        # Git 审批账本
+├── approval-ledger/requests/    # 修改请求
+└── approval-worktrees/          # 审批用临时 worktree
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "dev": "tsc --watch",
     "test": "node --test dist/tests/*.test.js",
     "setup": "node dist/main.js setup",
+    "instances": "node dist/main.js instances",
     "daemon": "bash scripts/daemon.sh",
+    "daemon:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/daemon.ps1",
     "visualize": "npx tsx src/tools/visualize-logs.ts"
   },
   "dependencies": {

--- a/scripts/daemon.ps1
+++ b/scripts/daemon.ps1
@@ -1,0 +1,106 @@
+param(
+  [Parameter(Position = 0, Mandatory = $true)]
+  [ValidateSet('start', 'stop', 'restart', 'status', 'logs')]
+  [string]$Command,
+
+  [string]$Instance = $(if ($env:WCC_INSTANCE) { $env:WCC_INSTANCE } else { 'default' })
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Instance -notmatch '^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$') {
+  throw "Invalid instance id: $Instance"
+}
+
+$projectDir = Split-Path -Parent $PSScriptRoot
+$baseDataDir = if ($env:WCC_DATA_DIR) {
+  [System.IO.Path]::GetFullPath($env:WCC_DATA_DIR)
+} else {
+  Join-Path $HOME '.wechat-claude-code'
+}
+$dataDir = if ($Instance -eq 'default') {
+  $baseDataDir
+} else {
+  Join-Path (Join-Path $baseDataDir 'instances') $Instance
+}
+$logsDir = Join-Path $dataDir 'logs'
+$pidPath = Join-Path $dataDir 'wechat-claude-code.pid'
+$stdoutPath = Join-Path $logsDir 'stdout.log'
+$stderrPath = Join-Path $logsDir 'stderr.log'
+$entryPath = Join-Path $projectDir 'dist\main.js'
+
+function Get-ManagedProcess {
+  if (-not (Test-Path -LiteralPath $pidPath)) { return $null }
+  $savedPid = (Get-Content -LiteralPath $pidPath -Raw).Trim()
+  if ($savedPid -notmatch '^\d+$') { return $null }
+  $process = Get-CimInstance Win32_Process -Filter "ProcessId = $savedPid" -ErrorAction SilentlyContinue
+  if (-not $process) { return $null }
+  if ($process.CommandLine -notlike "*$entryPath*" -or $process.CommandLine -notlike "*--instance*$Instance*") {
+    return $null
+  }
+  return $process
+}
+
+function Start-Bridge {
+  $existing = Get-ManagedProcess
+  if ($existing) {
+    Write-Output "Already running (instance: $Instance, PID: $($existing.ProcessId))"
+    return
+  }
+  New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+  $node = (Get-Command node -ErrorAction Stop).Source
+  $startParameters = @{
+    FilePath = $node
+    ArgumentList = @("`"$entryPath`"", 'start', '--instance', $Instance)
+    WorkingDirectory = $projectDir
+    RedirectStandardOutput = $stdoutPath
+    RedirectStandardError = $stderrPath
+    WindowStyle = 'Hidden'
+    PassThru = $true
+  }
+  $process = Start-Process @startParameters
+  Set-Content -LiteralPath $pidPath -Value $process.Id -Encoding ascii
+  Write-Output "Started (instance: $Instance, PID: $($process.Id))"
+}
+
+function Stop-Bridge {
+  $process = Get-ManagedProcess
+  if (-not $process) {
+    if (Test-Path -LiteralPath $pidPath) { Remove-Item -LiteralPath $pidPath -Force }
+    Write-Output "Not running (instance: $Instance)"
+    return
+  }
+  Stop-Process -Id $process.ProcessId
+  Wait-Process -Id $process.ProcessId -Timeout 10 -ErrorAction SilentlyContinue
+  if (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue) {
+    Stop-Process -Id $process.ProcessId -Force
+  }
+  if (Test-Path -LiteralPath $pidPath) { Remove-Item -LiteralPath $pidPath -Force }
+  Write-Output "Stopped (instance: $Instance, PID: $($process.ProcessId))"
+}
+
+function Show-Status {
+  $process = Get-ManagedProcess
+  if ($process) {
+    Write-Output "Running (instance: $Instance, PID: $($process.ProcessId))"
+  } else {
+    Write-Output "Not running (instance: $Instance)"
+  }
+}
+
+function Show-Logs {
+  foreach ($path in @($stdoutPath, $stderrPath)) {
+    if (Test-Path -LiteralPath $path) {
+      Write-Output "--- $(Split-Path -Leaf $path) ---"
+      Get-Content -LiteralPath $path -Tail 100
+    }
+  }
+}
+
+switch ($Command) {
+  'start' { Start-Bridge }
+  'stop' { Stop-Bridge }
+  'restart' { Stop-Bridge; Start-Bridge }
+  'status' { Show-Status }
+  'logs' { Show-Logs }
+}

--- a/scripts/daemon.ps1
+++ b/scripts/daemon.ps1
@@ -1,9 +1,14 @@
 param(
   [Parameter(Position = 0, Mandatory = $true)]
-  [ValidateSet('start', 'stop', 'restart', 'status', 'logs')]
+  [ValidateSet(
+    'start', 'stop', 'restart', 'status', 'logs',
+    'enable-startup', 'disable-startup', 'startup-status', 'run-task'
+  )]
   [string]$Command,
 
-  [string]$Instance = $(if ($env:WCC_INSTANCE) { $env:WCC_INSTANCE } else { 'default' })
+  [string]$Instance = $(if ($env:WCC_INSTANCE) { $env:WCC_INSTANCE } else { 'default' }),
+  [string]$DataDirectory,
+  [string]$NodeExecutable
 )
 
 $ErrorActionPreference = 'Stop'
@@ -13,7 +18,9 @@ if ($Instance -notmatch '^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$') {
 }
 
 $projectDir = Split-Path -Parent $PSScriptRoot
-$baseDataDir = if ($env:WCC_DATA_DIR) {
+$baseDataDir = if ($DataDirectory) {
+  [System.IO.Path]::GetFullPath($DataDirectory)
+} elseif ($env:WCC_DATA_DIR) {
   [System.IO.Path]::GetFullPath($env:WCC_DATA_DIR)
 } else {
   Join-Path $HOME '.wechat-claude-code'
@@ -28,6 +35,12 @@ $pidPath = Join-Path $dataDir 'wechat-claude-code.pid'
 $stdoutPath = Join-Path $logsDir 'stdout.log'
 $stderrPath = Join-Path $logsDir 'stderr.log'
 $entryPath = Join-Path $projectDir 'dist\main.js'
+$taskName = "WeChatClaudeCode-$Instance"
+$nodePath = if ($NodeExecutable) {
+  [System.IO.Path]::GetFullPath($NodeExecutable)
+} else {
+  (Get-Command node -ErrorAction Stop).Source
+}
 
 function Get-ManagedProcess {
   if (-not (Test-Path -LiteralPath $pidPath)) { return $null }
@@ -41,16 +54,28 @@ function Get-ManagedProcess {
   return $process
 }
 
-function Start-Bridge {
+function Get-StartupTask {
+  return Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+}
+
+function Wait-ForBridge {
+  for ($attempt = 0; $attempt -lt 100; $attempt++) {
+    $process = Get-ManagedProcess
+    if ($process) { return $process }
+    Start-Sleep -Milliseconds 100
+  }
+  throw "Bridge did not start within 10 seconds (instance: $Instance)"
+}
+
+function Start-UnmanagedBridge {
   $existing = Get-ManagedProcess
   if ($existing) {
     Write-Output "Already running (instance: $Instance, PID: $($existing.ProcessId))"
     return
   }
   New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
-  $node = (Get-Command node -ErrorAction Stop).Source
   $startParameters = @{
-    FilePath = $node
+    FilePath = $nodePath
     ArgumentList = @("`"$entryPath`"", 'start', '--instance', $Instance)
     WorkingDirectory = $projectDir
     RedirectStandardOutput = $stdoutPath
@@ -60,31 +85,169 @@ function Start-Bridge {
   }
   $process = Start-Process @startParameters
   Set-Content -LiteralPath $pidPath -Value $process.Id -Encoding ascii
-  Write-Output "Started (instance: $Instance, PID: $($process.Id))"
+  Write-Output "Started (instance: $Instance, PID: $($process.Id), mode: manual)"
+}
+
+function Start-Bridge {
+  $existing = Get-ManagedProcess
+  if ($existing) {
+    Write-Output "Already running (instance: $Instance, PID: $($existing.ProcessId))"
+    return
+  }
+
+  $task = Get-StartupTask
+  if (-not $task) {
+    Start-UnmanagedBridge
+    return
+  }
+
+  if ($task.State -eq 'Running') {
+    Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+  }
+  Start-ScheduledTask -TaskName $taskName
+  $process = Wait-ForBridge
+  Write-Output "Started (instance: $Instance, PID: $($process.ProcessId), mode: scheduled)"
 }
 
 function Stop-Bridge {
   $process = Get-ManagedProcess
-  if (-not $process) {
-    if (Test-Path -LiteralPath $pidPath) { Remove-Item -LiteralPath $pidPath -Force }
-    Write-Output "Not running (instance: $Instance)"
-    return
+  $task = Get-StartupTask
+  if ($task -and $task.State -eq 'Running') {
+    Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
   }
-  Stop-Process -Id $process.ProcessId
-  Wait-Process -Id $process.ProcessId -Timeout 10 -ErrorAction SilentlyContinue
-  if (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue) {
-    Stop-Process -Id $process.ProcessId -Force
+
+  if ($process) {
+    Stop-Process -Id $process.ProcessId -ErrorAction SilentlyContinue
+    Wait-Process -Id $process.ProcessId -Timeout 10 -ErrorAction SilentlyContinue
+    if (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue) {
+      Stop-Process -Id $process.ProcessId -Force
+    }
   }
   if (Test-Path -LiteralPath $pidPath) { Remove-Item -LiteralPath $pidPath -Force }
-  Write-Output "Stopped (instance: $Instance, PID: $($process.ProcessId))"
+
+  if ($process) {
+    Write-Output "Stopped (instance: $Instance, PID: $($process.ProcessId))"
+  } else {
+    Write-Output "Not running (instance: $Instance)"
+  }
 }
 
 function Show-Status {
   $process = Get-ManagedProcess
+  $task = Get-StartupTask
   if ($process) {
     Write-Output "Running (instance: $Instance, PID: $($process.ProcessId))"
   } else {
     Write-Output "Not running (instance: $Instance)"
+  }
+  if ($task) {
+    Write-Output "Autostart: enabled at logon (task: $taskName, state: $($task.State))"
+  } else {
+    Write-Output "Autostart: disabled (task: $taskName)"
+  }
+}
+
+function Show-StartupStatus {
+  $task = Get-StartupTask
+  if (-not $task) {
+    Write-Output "Autostart disabled (instance: $Instance, task: $taskName)"
+    return
+  }
+  $info = Get-ScheduledTaskInfo -TaskName $taskName
+  Write-Output "Autostart enabled (instance: $Instance, task: $taskName, state: $($task.State))"
+  Write-Output "Last run: $($info.LastRunTime); last result: $($info.LastTaskResult); next run: $($info.NextRunTime)"
+}
+
+function Enable-Startup {
+  if (-not (Test-Path -LiteralPath $entryPath)) {
+    throw "Built entry point not found: $entryPath. Run npm run build first."
+  }
+  Stop-Bridge
+  New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+
+  $powershellPath = (Get-Command powershell.exe -ErrorAction Stop).Source
+  $scriptPath = $PSCommandPath
+  $arguments = @(
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy', 'Bypass',
+    '-WindowStyle', 'Hidden',
+    '-File', "`"$scriptPath`"",
+    'run-task',
+    '-Instance', "`"$Instance`"",
+    '-DataDirectory', "`"$baseDataDir`"",
+    '-NodeExecutable', "`"$nodePath`""
+  ) -join ' '
+  $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+  $action = New-ScheduledTaskAction -Execute $powershellPath -Argument $arguments -WorkingDirectory $projectDir
+  $trigger = New-ScheduledTaskTrigger -AtLogOn -User $identity
+  $principal = New-ScheduledTaskPrincipal -UserId $identity -LogonType Interactive -RunLevel Limited
+  $settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -RestartCount 999 `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -ExecutionTimeLimit ([TimeSpan]::Zero) `
+    -MultipleInstances IgnoreNew
+
+  Register-ScheduledTask `
+    -TaskName $taskName `
+    -Action $action `
+    -Trigger $trigger `
+    -Principal $principal `
+    -Settings $settings `
+    -Description "WeChat Claude Code instance '$Instance'; starts at user logon and restarts after failure." `
+    -Force | Out-Null
+
+  Start-ScheduledTask -TaskName $taskName
+  $process = Wait-ForBridge
+  Write-Output "Autostart enabled and running (instance: $Instance, PID: $($process.ProcessId), task: $taskName)"
+}
+
+function Disable-Startup {
+  $task = Get-StartupTask
+  if (-not $task) {
+    Write-Output "Autostart already disabled (instance: $Instance, task: $taskName)"
+    return
+  }
+  Stop-Bridge
+  Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+  Write-Output "Autostart disabled (instance: $Instance, task: $taskName)"
+  Start-UnmanagedBridge
+}
+
+function Run-TaskBridge {
+  while ($true) {
+    $existing = Get-ManagedProcess
+    if ($existing) {
+      Wait-Process -Id $existing.ProcessId -ErrorAction SilentlyContinue
+    } else {
+      New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+      $startParameters = @{
+        FilePath = $nodePath
+        ArgumentList = @("`"$entryPath`"", 'start', '--instance', $Instance)
+        WorkingDirectory = $projectDir
+        RedirectStandardOutput = $stdoutPath
+        RedirectStandardError = $stderrPath
+        WindowStyle = 'Hidden'
+        PassThru = $true
+      }
+      $process = Start-Process @startParameters
+      Set-Content -LiteralPath $pidPath -Value $process.Id -Encoding ascii
+      try {
+        $process.WaitForExit()
+      } finally {
+        if (Test-Path -LiteralPath $pidPath) {
+          $savedPid = (Get-Content -LiteralPath $pidPath -Raw).Trim()
+          if ($savedPid -eq [string]$process.Id) { Remove-Item -LiteralPath $pidPath -Force }
+        }
+      }
+    }
+
+    # Supervise the Node child directly. Task Scheduler's restart policy is a
+    # second layer for failures of this PowerShell supervisor itself.
+    Start-Sleep -Seconds 60
   }
 }
 
@@ -103,4 +266,8 @@ switch ($Command) {
   'restart' { Stop-Bridge; Start-Bridge }
   'status' { Show-Status }
   'logs' { Show-Logs }
+  'enable-startup' { Enable-Startup }
+  'disable-startup' { Disable-Startup }
+  'startup-status' { Show-StartupStatus }
+  'run-task' { Run-TaskBridge }
 }

--- a/scripts/daemon.sh
+++ b/scripts/daemon.sh
@@ -6,9 +6,41 @@ set -euo pipefail
 # Supports: macOS (launchd) / Linux (systemd + nohup fallback)
 # =============================================================================
 
-DATA_DIR="${HOME}/.wechat-claude-code"
+COMMAND="${1:-}"
+shift || true
+
+INSTANCE_ID="${WCC_INSTANCE:-default}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --instance)
+      INSTANCE_ID="${2:-}"
+      shift 2
+      ;;
+    --instance=*)
+      INSTANCE_ID="${1#--instance=}"
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! "$INSTANCE_ID" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$ ]]; then
+  echo "Invalid instance id: $INSTANCE_ID"
+  exit 1
+fi
+
+BASE_DATA_DIR="${WCC_DATA_DIR:-${HOME}/.wechat-claude-code}"
+if [ "$INSTANCE_ID" = "default" ]; then
+  DATA_DIR="$BASE_DATA_DIR"
+  SERVICE_NAME="wechat-claude-code"
+else
+  DATA_DIR="${BASE_DATA_DIR}/instances/${INSTANCE_ID}"
+  SERVICE_NAME="wechat-claude-code-${INSTANCE_ID}"
+fi
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-SERVICE_NAME="wechat-claude-code"
 
 # Platform detection
 OS_TYPE="$(uname -s)"
@@ -18,7 +50,11 @@ OS_TYPE="$(uname -s)"
 # =============================================================================
 
 macos_plist_label() {
-  echo "com.wechat-claude-code.bridge"
+  if [ "$INSTANCE_ID" = "default" ]; then
+    echo "com.wechat-claude-code.bridge"
+  else
+    echo "com.wechat-claude-code.bridge.${INSTANCE_ID}"
+  fi
 }
 
 macos_plist_path() {
@@ -43,7 +79,7 @@ macos_start() {
 
   # Collect Anthropic/Claude env vars for plist
   local plist_extra_env=""
-  for var in ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL CLAUDE_API_KEY; do
+  for var in ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL CLAUDE_API_KEY WCC_DATA_DIR; do
     if [ -n "${!var:-}" ]; then
       plist_extra_env="${plist_extra_env}    <key>${var}</key>
     <string>${!var}</string>
@@ -63,6 +99,8 @@ macos_start() {
     <string>${node_bin}</string>
     <string>${PROJECT_DIR}/dist/main.js</string>
     <string>start</string>
+    <string>--instance</string>
+    <string>${INSTANCE_ID}</string>
   </array>
   <key>WorkingDirectory</key>
   <string>${PROJECT_DIR}</string>
@@ -84,7 +122,7 @@ ${plist_extra_env}  </dict>
 PLIST
 
   launchctl load "$plist_path"
-  echo "Started wechat-claude-code daemon (macOS launchd)"
+  echo "Started wechat-claude-code daemon (instance: ${INSTANCE_ID}, macOS launchd)"
 }
 
 macos_stop() {
@@ -98,7 +136,7 @@ macos_stop() {
 
 macos_status() {
   if macos_is_loaded; then
-    local pid=$(pgrep -f "dist/main.js start" 2>/dev/null | head -1)
+    local pid=$(pgrep -f "dist/main.js start --instance ${INSTANCE_ID}" 2>/dev/null | head -1)
     if [ -n "$pid" ]; then
       echo "Running (PID: $pid)"
     else
@@ -175,7 +213,7 @@ linux_create_service_file() {
 
   # Collect Anthropic/Claude env vars to pass through to the service
   local extra_env=""
-  for var in ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL CLAUDE_API_KEY; do
+  for var in ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL CLAUDE_API_KEY WCC_DATA_DIR; do
     if [ -n "${!var:-}" ]; then
       extra_env="${extra_env}Environment=${var}=${!var}
 "
@@ -190,7 +228,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=${node_bin} ${PROJECT_DIR}/dist/main.js start
+ExecStart=${node_bin} ${PROJECT_DIR}/dist/main.js start --instance ${INSTANCE_ID}
 WorkingDirectory=${PROJECT_DIR}
 Restart=always
 RestartSec=10
@@ -229,6 +267,7 @@ linux_direct_start() {
 
   echo "Starting wechat-claude-code daemon (direct mode)..."
   nohup "$node_bin" "${PROJECT_DIR}/dist/main.js" start \
+    --instance "$INSTANCE_ID" \
     >> "$DATA_DIR/logs/stdout.log" \
     2>> "$DATA_DIR/logs/stderr.log" &
   local pid=$!
@@ -391,7 +430,7 @@ main() {
         status)  macos_status ;;
         logs)    macos_logs ;;
         *)
-          echo "Usage: daemon.sh {start|stop|restart|status|logs}"
+          echo "Usage: daemon.sh {start|stop|restart|status|logs} [--instance NAME]"
           echo "Platform: macOS (launchd)"
           exit 1
           ;;
@@ -405,7 +444,7 @@ main() {
         status)  linux_status ;;
         logs)    linux_logs ;;
         *)
-          echo "Usage: daemon.sh {start|stop|restart|status|logs}"
+          echo "Usage: daemon.sh {start|stop|restart|status|logs} [--instance NAME]"
           echo "Platform: Linux (systemd)"
           exit 1
           ;;
@@ -419,4 +458,4 @@ main() {
   esac
 }
 
-main "$@"
+main "$COMMAND"

--- a/src/claude/provider.ts
+++ b/src/claude/provider.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
-import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { delimiter, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createInterface } from 'node:readline';
 import { logger } from '../logger.js';
@@ -41,6 +41,29 @@ export interface QueryResult {
 // ---------------------------------------------------------------------------
 
 const TEMP_DIR = join(tmpdir(), 'wechat-claude-code');
+
+export function resolveClaudeExecutable(
+  environment: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const override = environment.WCC_CLAUDE_PATH?.trim();
+  if (override) return resolve(override);
+  if (platform !== 'win32') return 'claude';
+
+  const pathValue = environment.PATH ?? environment.Path ?? '';
+  for (const rawDirectory of pathValue.split(delimiter)) {
+    const directory = rawDirectory.trim().replace(/^"|"$/g, '');
+    if (!directory) continue;
+    const candidates = [
+      join(directory, 'claude.exe'),
+      join(directory, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe'),
+    ];
+    const executable = candidates.find((candidate) => existsSync(candidate));
+    if (executable) return executable;
+  }
+
+  return 'claude.exe';
+}
 
 function saveImageTemp(images: NonNullable<QueryOptions['images']>): string[] {
   mkdirSync(TEMP_DIR, { recursive: true });
@@ -201,11 +224,13 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
     permission = 'admin',
   } = options;
 
+  const claudeExecutable = resolveClaudeExecutable();
   logger.info("Starting Claude CLI query", {
     cwd,
     model,
     resume: !!resume,
     hasImages: !!images?.length,
+    executable: claudeExecutable,
   });
 
   // Build CLI arguments
@@ -234,7 +259,7 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
     };
 
     try {
-      child = spawn('claude', args, {
+      child = spawn(claudeExecutable, args, {
         cwd,
         stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env },

--- a/src/claude/provider.ts
+++ b/src/claude/provider.ts
@@ -27,6 +27,7 @@ export interface QueryOptions {
   onTurnEnd?: (stopReason: string) => Promise<void> | void;
   /** Optional abort controller to cancel the query (e.g. when user sends a new message). */
   abortController?: AbortController;
+  permission?: 'admin' | 'read-only';
 }
 
 export interface QueryResult {
@@ -162,6 +163,30 @@ export function handleStreamLine(
 // Core function
 // ---------------------------------------------------------------------------
 
+export function buildClaudeArgs(options: Pick<QueryOptions, 'resume' | 'model' | 'systemPrompt' | 'permission'>): string[] {
+  const args: string[] = [
+    '-p', '-',
+    '--output-format', 'stream-json',
+    '--verbose',
+    '--include-partial-messages',
+  ];
+
+  if ((options.permission ?? 'admin') === 'admin') {
+    args.push('--dangerously-skip-permissions');
+  } else {
+    args.push(
+      '--safe-mode',
+      '--permission-mode', 'plan',
+      '--tools', 'Read,Grep,Glob',
+    );
+  }
+
+  if (options.resume) args.push('--resume', options.resume);
+  if (options.model) args.push('--model', options.model);
+  if (options.systemPrompt) args.push('--append-system-prompt', options.systemPrompt);
+  return args;
+}
+
 export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
   const {
     prompt,
@@ -173,6 +198,7 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
     onText,
     onTurnEnd,
     abortController,
+    permission = 'admin',
   } = options;
 
   logger.info("Starting Claude CLI query", {
@@ -183,17 +209,7 @@ export async function claudeQuery(options: QueryOptions): Promise<QueryResult> {
   });
 
   // Build CLI arguments
-  const args: string[] = [
-    '-p', '-',
-    '--output-format', 'stream-json',
-    '--verbose',
-    '--include-partial-messages',
-    '--dangerously-skip-permissions',
-  ];
-
-  if (resume) args.push('--resume', resume);
-  if (model) args.push('--model', model);
-  if (systemPrompt) args.push('--append-system-prompt', systemPrompt);
+  const args = buildClaudeArgs({ resume, model, systemPrompt, permission });
 
   // Handle images: save to temp files and append paths to prompt
   const tempImagePaths = images?.length ? saveImageTemp(images) : [];

--- a/src/commands/handlers.ts
+++ b/src/commands/handlers.ts
@@ -1,7 +1,6 @@
 import type { CommandContext, CommandResult } from './router.js';
 import { scanAllSkills, formatSkillList, findSkill, type SkillInfo } from '../claude/skill-scanner.js';
 import { loadConfig, saveConfig } from '../config.js';
-import { DEFAULT_WORKING_DIR } from '../constants.js';
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { resolve, basename, join } from 'node:path';
 import { homedir } from 'node:os';
@@ -134,7 +133,7 @@ export function handleHistory(ctx: CommandContext, args: string): CommandResult 
 /** 完全重置会话（包括工作目录等设置） */
 export function handleReset(ctx: CommandContext): CommandResult {
   const newSession = ctx.clearSession();
-  newSession.workingDirectory = DEFAULT_WORKING_DIR;
+  newSession.workingDirectory = loadConfig().workingDirectory;
   Object.assign(ctx.session, newSession);
   return { reply: '✅ 会话已完全重置，所有设置恢复默认。', handled: true };
 }

--- a/src/commands/handlers.ts
+++ b/src/commands/handlers.ts
@@ -25,7 +25,14 @@ const HELP_TEXT = `可用命令：
 配置：
   /cwd [路径]       查看或切换工作目录
   /model [名称]     查看或切换 Claude 模型
-  /prompt [内容]    查看或设置系统提示词（全局生效）
+  /prompt [内容]    查看或设置系统提示词（当前实例）
+
+Git 审批：
+  /request <需求>   提交修改请求
+  /requests [all]   查看请求（仅管理员）
+  /approve <请求号> 批准并执行（仅管理员）
+  /reject <请求号>  拒绝请求（仅管理员）
+  /recover <请求号> 收口中断审批（仅管理员）
 
 其他：
   /skills [full]    列出已安装的 skill（full 显示描述）
@@ -84,6 +91,8 @@ export function handleStatus(ctx: CommandContext): CommandResult {
   const lines = [
     '📊 会话状态',
     '',
+    `实例: ${ctx.instance.id}`,
+    `角色: ${ctx.instance.role}`,
     `工作目录: ${s.workingDirectory}`,
     `模型: ${s.model ?? '默认'}`,
     `会话ID: ${s.sdkSessionId ?? '无'}`,

--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -2,9 +2,14 @@ import type { Session } from '../session.js';
 import { findSkill } from '../claude/skill-scanner.js';
 import { logger } from '../logger.js';
 import { handleHelp, handleClear, handleCwd, handleModel, handleStatus, handleSkills, handleHistory, handleReset, handleCompact, handleUndo, handleVersion, handlePrompt, handleSend, handleUnknown } from './handlers.js';
+import type { InstanceConfig } from '../instances.js';
+import type { GitApprovalStore } from '../governance/approval-store.js';
+import { handleApprove, handleRecover, handleReject, handleRequest, handleRequests } from '../governance/commands.js';
 
 export interface CommandContext {
   accountId: string;
+  instance: InstanceConfig;
+  approvalStore: GitApprovalStore;
   session: Session;
   updateSession: (partial: Partial<Session>) => void;
   clearSession: () => Session;
@@ -17,6 +22,9 @@ export interface CommandResult {
   handled: boolean;
   claudePrompt?: string;
   sendFile?: string; // Absolute path to a file to send to the user
+  cwdOverride?: string;
+  approvalRequestId?: string;
+  queryPermission?: 'admin' | 'read-only';
 }
 
 /**
@@ -68,6 +76,16 @@ export function routeCommand(ctx: CommandContext): CommandResult {
       return handleCompact(ctx);
     case 'send':
       return handleSend(ctx, args);
+    case 'request':
+      return handleRequest(ctx, args);
+    case 'requests':
+      return handleRequests(ctx, args);
+    case 'approve':
+      return handleApprove(ctx, args);
+    case 'reject':
+      return handleReject(ctx, args);
+    case 'recover':
+      return handleRecover(ctx, args);
     case 'version':
     case 'v':
       return handleVersion();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,6 @@
 import { readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
-import { DEFAULT_WORKING_DIR } from "./constants.js";
+import { DATA_DIR, DEFAULT_WORKING_DIR } from "./constants.js";
 
 export interface Config {
   workingDirectory: string;
@@ -9,7 +8,7 @@ export interface Config {
   systemPrompt?: string;
 }
 
-const CONFIG_DIR = join(homedir(), ".wechat-claude-code");
+const CONFIG_DIR = DATA_DIR;
 const CONFIG_PATH = join(CONFIG_DIR, "config.json");
 
 const DEFAULT_CONFIG: Config = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,9 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { BASE_DATA_DIR, INSTANCE_DATA_DIR } from './runtime.js';
 
-export const DATA_DIR = process.env.WCC_DATA_DIR || join(homedir(), '.wechat-claude-code');
+export { BASE_DATA_DIR };
+export const DATA_DIR = INSTANCE_DATA_DIR;
 
 export const DEFAULT_WORKING_DIR = join(homedir(), 'Documents', 'ClaudeCode');
 

--- a/src/file-lock.ts
+++ b/src/file-lock.ts
@@ -1,0 +1,62 @@
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+const LOCK_WAIT_MS = 50;
+const LOCK_TIMEOUT_MS = 10_000;
+const INCOMPLETE_LOCK_STALE_MS = 60_000;
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function removeStaleLock(lockPath: string): boolean {
+  try {
+    const owner = Number.parseInt(readFileSync(lockPath, 'utf8').trim(), 10);
+    if (Number.isSafeInteger(owner) && owner > 0) {
+      try {
+        process.kill(owner, 0);
+        return false;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ESRCH') return false;
+      }
+    } else if (Date.now() - statSync(lockPath).mtimeMs < INCOMPLETE_LOCK_STALE_MS) {
+      return false;
+    }
+    unlinkSync(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function withFileLock<T>(lockPath: string, busyMessage: string, operation: () => T): T {
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  let descriptor: number | undefined;
+  while (descriptor === undefined) {
+    try {
+      descriptor = openSync(lockPath, 'wx', 0o600);
+      writeFileSync(descriptor, `${process.pid}\n`, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      if (removeStaleLock(lockPath)) continue;
+      if (Date.now() >= deadline) throw new Error(busyMessage);
+      sleepSync(LOCK_WAIT_MS);
+    }
+  }
+
+  try {
+    return operation();
+  } finally {
+    closeSync(descriptor);
+    try { unlinkSync(lockPath); } catch { /* best effort */ }
+  }
+}

--- a/src/governance/approval-store.ts
+++ b/src/governance/approval-store.ts
@@ -1,0 +1,379 @@
+import { randomBytes } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { BASE_DATA_DIR } from '../constants.js';
+import { withFileLock } from '../file-lock.js';
+
+export type ChangeRequestStatus =
+  | 'pending'
+  | 'executing'
+  | 'completed'
+  | 'ready'
+  | 'rejected'
+  | 'failed'
+  | 'no_changes';
+
+export interface ChangeRequest {
+  id: string;
+  status: ChangeRequestStatus;
+  requesterInstanceId: string;
+  requesterAccountId: string;
+  targetRepo: string;
+  targetCwd: string;
+  prompt: string;
+  createdAt: string;
+  updatedAt: string;
+  reviewerInstanceId?: string;
+  reviewedAt?: string;
+  rejectionReason?: string;
+  baseHead?: string;
+  targetBranch?: string;
+  proposalBranch?: string;
+  worktreePath?: string;
+  resultCommit?: string;
+  error?: string;
+}
+
+export interface ApprovalExecution {
+  request: ChangeRequest;
+  cwd: string;
+  prompt: string;
+}
+
+export interface ApprovalFinalization {
+  request: ChangeRequest;
+  message: string;
+}
+
+export interface AdminAuditContext {
+  instanceId: string;
+  targetRepo: string;
+  baseHead: string;
+  targetBranch: string;
+  prompt: string;
+}
+
+export interface AdminAuditFinalization {
+  commit?: string;
+  message?: string;
+}
+
+interface GitResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+function runGit(cwd: string, args: string[], allowFailure = false): GitResult {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  const status = result.status ?? 1;
+  const output = {
+    stdout: (result.stdout ?? '').trim(),
+    stderr: (result.stderr ?? '').trim(),
+    status,
+  };
+  if (!allowFailure && (result.error || status !== 0)) {
+    throw new Error(output.stderr || output.stdout || result.error?.message || `git exited with ${status}`);
+  }
+  return output;
+}
+
+function sanitizeSubject(text: string): string {
+  return text.replace(/[\r\n]+/g, ' ').trim().slice(0, 72) || 'approved change';
+}
+
+function atomicWriteJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  renameSync(temporaryPath, path);
+}
+
+export function resolveGitRoot(path: string): string {
+  const absolute = resolve(path);
+  const result = runGit(absolute, ['rev-parse', '--show-toplevel'], true);
+  if (result.status !== 0 || !result.stdout) {
+    throw new Error(`Change requests require a Git repository: ${absolute}`);
+  }
+  return resolve(result.stdout);
+}
+
+export class GitApprovalStore {
+  readonly ledgerDir: string;
+  readonly worktreesDir: string;
+  private readonly lockPath: string;
+
+  constructor(baseDir = BASE_DATA_DIR) {
+    this.ledgerDir = join(baseDir, 'approval-ledger');
+    this.worktreesDir = join(baseDir, 'approval-worktrees');
+    this.lockPath = join(baseDir, 'approval-ledger.lock');
+  }
+
+  prepareAdminAudit(workingDirectory: string, instanceId: string, prompt: string): AdminAuditContext {
+    const targetRepo = resolveGitRoot(workingDirectory);
+    const dirty = runGit(targetRepo, ['status', '--porcelain']).stdout;
+    if (dirty) {
+      throw new Error(`Target repository has uncommitted changes: ${targetRepo}`);
+    }
+    const baseHead = runGit(targetRepo, ['rev-parse', 'HEAD']).stdout;
+    const targetBranch = runGit(targetRepo, ['branch', '--show-current']).stdout;
+    if (!targetBranch) throw new Error('Admin write access requires the target repository to be on a branch');
+    return { instanceId, targetRepo, baseHead, targetBranch, prompt: prompt.trim() };
+  }
+
+  finalizeAdminAudit(context: AdminAuditContext, executionError?: string): AdminAuditFinalization {
+    const dirty = runGit(context.targetRepo, ['status', '--porcelain']).stdout;
+    if (dirty) {
+      runGit(context.targetRepo, ['add', '-A']);
+      const prefix = executionError ? 'checkpoint failed admin task' : 'admin task';
+      runGit(context.targetRepo, [
+        '-c', 'user.name=WeChat Claude Code',
+        '-c', 'user.email=wechat-claude-code@localhost',
+        'commit', '-m', `wcc: ${prefix} by ${context.instanceId} - ${sanitizeSubject(context.prompt)}`,
+      ]);
+    }
+    const commit = runGit(context.targetRepo, ['rev-parse', 'HEAD']).stdout;
+    if (commit === context.baseHead) return {};
+    return {
+      commit,
+      message: executionError
+        ? `管理员任务的部分修改已保存为 ${commit}。`
+        : `管理员修改已保存为 Git 提交 ${commit}。`,
+    };
+  }
+
+  submit(input: {
+    requesterInstanceId: string;
+    requesterAccountId: string;
+    workingDirectory: string;
+    prompt: string;
+  }): ChangeRequest {
+    const prompt = input.prompt.trim();
+    if (!prompt) throw new Error('Change request cannot be empty');
+    if (prompt.length > 20_000) throw new Error('Change request is too long (max 20000 characters)');
+    const targetCwd = resolve(input.workingDirectory);
+    const targetRepo = resolveGitRoot(targetCwd);
+    const targetRelativePath = relative(targetRepo, targetCwd);
+    if (targetRelativePath.startsWith('..')) {
+      throw new Error(`Working directory is outside the target repository: ${targetCwd}`);
+    }
+
+    return this.withLock(() => {
+      this.ensureLedger();
+      const now = new Date().toISOString();
+      const id = `${now.replace(/[-:.TZ]/g, '').slice(0, 14)}-${randomBytes(3).toString('hex')}`;
+      const request: ChangeRequest = {
+        id,
+        status: 'pending',
+        requesterInstanceId: input.requesterInstanceId,
+        requesterAccountId: input.requesterAccountId,
+        targetRepo,
+        targetCwd,
+        prompt,
+        createdAt: now,
+        updatedAt: now,
+      };
+      this.writeRequest(request, `request ${id} from ${input.requesterInstanceId}`);
+      return request;
+    });
+  }
+
+  list(status?: ChangeRequestStatus): ChangeRequest[] {
+    return this.withLock(() => {
+      this.ensureLedger();
+      const requestsDir = join(this.ledgerDir, 'requests');
+      if (!existsSync(requestsDir)) return [];
+      return readdirSync(requestsDir)
+        .filter((name) => name.endsWith('.json'))
+        .map((name) => JSON.parse(readFileSync(join(requestsDir, name), 'utf8')) as ChangeRequest)
+        .filter((request) => !status || request.status === status)
+        .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+    });
+  }
+
+  get(id: string): ChangeRequest {
+    this.validateRequestId(id);
+    const path = this.requestPath(id);
+    if (!existsSync(path)) throw new Error(`Change request not found: ${id}`);
+    return JSON.parse(readFileSync(path, 'utf8')) as ChangeRequest;
+  }
+
+  reject(id: string, reviewerInstanceId: string, reason?: string): ChangeRequest {
+    return this.withLock(() => {
+      this.ensureLedger();
+      const request = this.get(id);
+      if (request.status !== 'pending') {
+        throw new Error(`Only pending requests can be rejected (current: ${request.status})`);
+      }
+      const now = new Date().toISOString();
+      request.status = 'rejected';
+      request.reviewerInstanceId = reviewerInstanceId;
+      request.reviewedAt = now;
+      request.rejectionReason = reason?.trim() || undefined;
+      request.updatedAt = now;
+      this.writeRequest(request, `reject ${id}`);
+      return request;
+    });
+  }
+
+  prepareApproval(id: string, reviewerInstanceId: string): ApprovalExecution {
+    return this.withLock(() => {
+      this.ensureLedger();
+      const request = this.get(id);
+      if (request.status !== 'pending') {
+        throw new Error(`Only pending requests can be approved (current: ${request.status})`);
+      }
+
+      const targetRepo = resolveGitRoot(request.targetRepo);
+      const dirty = runGit(targetRepo, ['status', '--porcelain']).stdout;
+      if (dirty) {
+        throw new Error(`Target repository has uncommitted changes: ${targetRepo}`);
+      }
+      const baseHead = runGit(targetRepo, ['rev-parse', 'HEAD']).stdout;
+      const targetBranch = runGit(targetRepo, ['branch', '--show-current']).stdout;
+      if (!targetBranch) throw new Error('Approval requires the target repository to be on a branch');
+
+      const proposalBranch = `wcc/request/${request.id}`;
+      const worktreePath = join(this.worktreesDir, request.id);
+      mkdirSync(dirname(worktreePath), { recursive: true });
+      if (existsSync(worktreePath)) throw new Error(`Approval worktree already exists: ${worktreePath}`);
+      runGit(targetRepo, ['worktree', 'add', '-b', proposalBranch, worktreePath, baseHead]);
+
+      const now = new Date().toISOString();
+      Object.assign(request, {
+        status: 'executing' as const,
+        reviewerInstanceId,
+        reviewedAt: now,
+        updatedAt: now,
+        baseHead,
+        targetBranch,
+        proposalBranch,
+        worktreePath,
+      });
+      this.writeRequest(request, `approve ${id}`);
+
+      return {
+        request,
+        cwd: join(worktreePath, relative(targetRepo, request.targetCwd || targetRepo)),
+        prompt: [
+          `Implement approved change request ${request.id}.`,
+          `Original requester: ${request.requesterInstanceId}`,
+          '',
+          request.prompt,
+          '',
+          'Work only inside the current Git worktree.',
+          'Do not run git commit, git merge, git reset, or git checkout; the bridge will create and merge the audit commit.',
+        ].join('\n'),
+      };
+    });
+  }
+
+  finalizeApproval(id: string, executionError?: string): ApprovalFinalization {
+    return this.withLock(() => {
+      this.ensureLedger();
+      const request = this.get(id);
+      if (request.status !== 'executing' || !request.worktreePath || !request.baseHead || !request.targetBranch) {
+        throw new Error(`Request is not executing: ${id}`);
+      }
+
+      const worktreePath = request.worktreePath;
+      const targetRepo = resolveGitRoot(request.targetRepo);
+      const dirty = runGit(worktreePath, ['status', '--porcelain']).stdout;
+      if (dirty) {
+        runGit(worktreePath, ['add', '-A']);
+        const subject = sanitizeSubject(request.prompt);
+        const prefix = executionError ? 'checkpoint failed request' : 'apply request';
+        runGit(worktreePath, [
+          '-c', 'user.name=WeChat Claude Code',
+          '-c', 'user.email=wechat-claude-code@localhost',
+          'commit', '-m', `wcc: ${prefix} ${request.id} - ${subject}`,
+        ]);
+      }
+
+      const resultCommit = runGit(worktreePath, ['rev-parse', 'HEAD']).stdout;
+      const now = new Date().toISOString();
+      request.resultCommit = resultCommit;
+      request.updatedAt = now;
+      request.error = executionError;
+
+      let message: string;
+      if (resultCommit === request.baseHead) {
+        request.status = executionError ? 'failed' : 'no_changes';
+        message = executionError
+          ? `Request ${id} failed without file changes: ${executionError}`
+          : `Request ${id} completed without file changes.`;
+      } else if (executionError) {
+        request.status = 'failed';
+        message = `Request ${id} failed; partial changes were saved in ${request.proposalBranch} at ${resultCommit}.`;
+      } else {
+        const currentBranch = runGit(targetRepo, ['branch', '--show-current']).stdout;
+        const currentHead = runGit(targetRepo, ['rev-parse', 'HEAD']).stdout;
+        const targetDirty = runGit(targetRepo, ['status', '--porcelain']).stdout;
+        if (currentBranch === request.targetBranch && currentHead === request.baseHead && !targetDirty) {
+          runGit(targetRepo, ['merge', '--ff-only', resultCommit]);
+          request.status = 'completed';
+          message = `Request ${id} merged as ${resultCommit}.`;
+        } else {
+          request.status = 'ready';
+          message = `Request ${id} is committed at ${resultCommit}, but the target branch changed; merge ${request.proposalBranch} manually.`;
+        }
+      }
+
+      const worktreeStatus = runGit(worktreePath, ['status', '--porcelain'], true).stdout;
+      if (!worktreeStatus) {
+        const removal = runGit(targetRepo, ['worktree', 'remove', worktreePath], true);
+        if (removal.status === 0 || !existsSync(worktreePath)) {
+          request.worktreePath = undefined;
+        }
+      }
+      this.writeRequest(request, `finalize ${id}: ${request.status}`);
+      return { request, message };
+    });
+  }
+
+  private ensureLedger(): void {
+    mkdirSync(this.ledgerDir, { recursive: true });
+    if (!existsSync(join(this.ledgerDir, '.git'))) {
+      runGit(this.ledgerDir, ['init', '-b', 'main']);
+    }
+  }
+
+  private requestPath(id: string): string {
+    this.validateRequestId(id);
+    return join(this.ledgerDir, 'requests', `${id}.json`);
+  }
+
+  private validateRequestId(id: string): void {
+    if (!/^\d{14}-[a-f0-9]{6}$/.test(id)) throw new Error(`Invalid change request id: ${id}`);
+  }
+
+  private writeRequest(request: ChangeRequest, commitMessage: string): void {
+    const path = this.requestPath(request.id);
+    atomicWriteJson(path, request);
+    const relativePath = join('requests', basename(path));
+    runGit(this.ledgerDir, ['add', '--', relativePath]);
+    const changed = runGit(this.ledgerDir, ['status', '--porcelain', '--', relativePath]).stdout;
+    if (!changed) return;
+    runGit(this.ledgerDir, [
+      '-c', 'user.name=WeChat Claude Code',
+      '-c', 'user.email=wechat-claude-code@localhost',
+      'commit', '-m', commitMessage, '--', relativePath,
+    ]);
+  }
+
+  private withLock<T>(operation: () => T): T {
+    return withFileLock(this.lockPath, 'Approval ledger is busy; retry shortly', operation);
+  }
+}

--- a/src/governance/commands.ts
+++ b/src/governance/commands.ts
@@ -1,0 +1,103 @@
+import type { CommandContext, CommandResult } from '../commands/router.js';
+
+function requireAdmin(ctx: CommandContext): CommandResult | null {
+  if (ctx.instance.role === 'admin') return null;
+  return { handled: true, reply: '⛔ 只有管理员实例可以执行审批操作。' };
+}
+
+export function handleRequest(ctx: CommandContext, args: string): CommandResult {
+  if (!args.trim()) {
+    return {
+      handled: true,
+      reply: '用法: /request <修改需求>\n请求会写入 Git 审批账本，等待管理员实例处理。',
+    };
+  }
+  try {
+    const request = ctx.approvalStore.submit({
+      requesterInstanceId: ctx.instance.id,
+      requesterAccountId: ctx.accountId,
+      workingDirectory: ctx.session.workingDirectory,
+      prompt: args,
+    });
+    return {
+      handled: true,
+      reply: [
+        '✅ 修改请求已提交',
+        `请求号: ${request.id}`,
+        `目标仓库: ${request.targetRepo}`,
+        '状态: pending',
+      ].join('\n'),
+    };
+  } catch (error) {
+    return { handled: true, reply: `❌ 提交失败: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+export function handleRequests(ctx: CommandContext, args: string): CommandResult {
+  const denied = requireAdmin(ctx);
+  if (denied) return denied;
+  try {
+    const showAll = args.trim().toLowerCase() === 'all';
+    const requests = showAll ? ctx.approvalStore.list() : ctx.approvalStore.list('pending');
+    if (requests.length === 0) {
+      return { handled: true, reply: showAll ? '暂无修改请求。' : '暂无待审批请求。' };
+    }
+    const lines = requests.slice(0, 20).map((request) => [
+      `${request.id} [${request.status}]`,
+      `  来自: ${request.requesterInstanceId}`,
+      `  仓库: ${request.targetRepo}`,
+      `  内容: ${request.prompt.replace(/[\r\n]+/g, ' ').slice(0, 160)}`,
+    ].join('\n'));
+    return {
+      handled: true,
+      reply: `📋 修改请求 (${requests.length})\n\n${lines.join('\n\n')}\n\n/approve <请求号>\n/reject <请求号> [原因]`,
+    };
+  } catch (error) {
+    return { handled: true, reply: `❌ 读取审批账本失败: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+export function handleApprove(ctx: CommandContext, args: string): CommandResult {
+  const denied = requireAdmin(ctx);
+  if (denied) return denied;
+  const id = args.trim().split(/\s+/, 1)[0];
+  if (!id) return { handled: true, reply: '用法: /approve <请求号>' };
+  try {
+    const execution = ctx.approvalStore.prepareApproval(id, ctx.instance.id);
+    return {
+      handled: true,
+      claudePrompt: execution.prompt,
+      cwdOverride: execution.cwd,
+      approvalRequestId: execution.request.id,
+      queryPermission: 'admin',
+    };
+  } catch (error) {
+    return { handled: true, reply: `❌ 无法批准请求: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+export function handleReject(ctx: CommandContext, args: string): CommandResult {
+  const denied = requireAdmin(ctx);
+  if (denied) return denied;
+  const [id, ...reasonParts] = args.trim().split(/\s+/);
+  if (!id) return { handled: true, reply: '用法: /reject <请求号> [原因]' };
+  try {
+    const request = ctx.approvalStore.reject(id, ctx.instance.id, reasonParts.join(' '));
+    return { handled: true, reply: `✅ 已拒绝请求 ${request.id}` };
+  } catch (error) {
+    return { handled: true, reply: `❌ 无法拒绝请求: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+export function handleRecover(ctx: CommandContext, args: string): CommandResult {
+  const denied = requireAdmin(ctx);
+  if (denied) return denied;
+  const id = args.trim().split(/\s+/, 1)[0];
+  if (!id) return { handled: true, reply: '用法: /recover <请求号>' };
+  try {
+    const finalized = ctx.approvalStore.finalizeApproval(id, '管理员收口了中断的审批执行');
+    return { handled: true, reply: `✅ ${finalized.message}` };
+  } catch (error) {
+    return { handled: true, reply: `❌ 无法恢复请求: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -1,0 +1,108 @@
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { withFileLock } from './file-lock.js';
+import { loadJson, saveJson } from './store.js';
+import {
+  BASE_DATA_DIR,
+  INSTANCE_DATA_DIR,
+  INSTANCE_ID,
+  type InstanceRole,
+  validateInstanceId,
+} from './runtime.js';
+
+export interface InstanceConfig {
+  id: string;
+  role: InstanceRole;
+  accountId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function instanceConfigPath(dataDir: string): string {
+  return join(dataDir, 'instance.json');
+}
+
+function withInstanceLock<T>(operation: () => T): T {
+  const lockPath = join(BASE_DATA_DIR, 'instances.lock');
+  return withFileLock(lockPath, 'Instance registry is busy; retry shortly', operation);
+}
+
+function defaultInstanceConfig(): InstanceConfig {
+  const now = new Date().toISOString();
+  return {
+    id: INSTANCE_ID,
+    role: INSTANCE_ID === 'default' ? 'admin' : 'requester',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function loadCurrentInstance(): InstanceConfig {
+  const config = loadJson<InstanceConfig>(instanceConfigPath(INSTANCE_DATA_DIR), defaultInstanceConfig());
+  if (config.id !== INSTANCE_ID) throw new Error(`Instance config id mismatch: expected ${INSTANCE_ID}, got ${config.id}`);
+  if (config.role !== 'admin' && config.role !== 'requester') throw new Error(`Invalid instance role: ${config.role}`);
+  return config;
+}
+
+export function isCurrentInstanceConfigured(): boolean {
+  return existsSync(instanceConfigPath(INSTANCE_DATA_DIR));
+}
+
+export function listInstances(): InstanceConfig[] {
+  const configs: InstanceConfig[] = [];
+  const defaultPath = instanceConfigPath(BASE_DATA_DIR);
+  if (existsSync(defaultPath)) {
+    const config = loadJson<InstanceConfig | null>(defaultPath, null);
+    if (config) configs.push(config);
+  } else {
+    const legacyAccounts = join(BASE_DATA_DIR, 'accounts');
+    if (existsSync(legacyAccounts) && readdirSync(legacyAccounts).some((name) => name.endsWith('.json'))) {
+      configs.push({
+        id: 'default',
+        role: 'admin',
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      });
+    }
+  }
+
+  const instancesDir = join(BASE_DATA_DIR, 'instances');
+  if (existsSync(instancesDir)) {
+    for (const name of readdirSync(instancesDir)) {
+      const path = instanceConfigPath(join(instancesDir, name));
+      if (!existsSync(path)) continue;
+      const config = loadJson<InstanceConfig | null>(path, null);
+      if (config && !configs.some((item) => item.id === config.id)) configs.push(config);
+    }
+  }
+  return configs;
+}
+
+export function hasAdminInstance(exceptId?: string): boolean {
+  return listInstances().some((instance) => instance.role === 'admin' && instance.id !== exceptId);
+}
+
+export function saveCurrentInstance(input: {
+  role: InstanceRole;
+  accountId?: string;
+}): InstanceConfig {
+  return withInstanceLock(() => {
+    validateInstanceId(INSTANCE_ID);
+    if (input.role === 'admin' && hasAdminInstance(INSTANCE_ID)) {
+      const currentAdmin = listInstances().find((instance) => instance.role === 'admin' && instance.id !== INSTANCE_ID);
+      throw new Error(`Admin instance already exists: ${currentAdmin?.id ?? 'unknown'}`);
+    }
+
+    const existing = loadJson<InstanceConfig | null>(instanceConfigPath(INSTANCE_DATA_DIR), null);
+    const now = new Date().toISOString();
+    const config: InstanceConfig = {
+      id: INSTANCE_ID,
+      role: input.role,
+      accountId: input.accountId ?? existing?.accountId,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    saveJson(instanceConfigPath(INSTANCE_DATA_DIR), config);
+    return config;
+  });
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, appendFileSync, readdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { DATA_DIR } from "./constants.js";
 
-const LOG_DIR = join(homedir(), ".wechat-claude-code", "logs");
+const LOG_DIR = join(DATA_DIR, "logs");
 const MAX_LOG_FILES = 30; // Keep at most 30 days of logs
 
 /** Clean up old log files beyond MAX_LOG_FILES retention. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,7 @@ import { TurnRouter } from './claude/turn-router.js';
 import { filterToolNoise } from './claude/tool-noise-filter.js';
 import { loadConfig, saveConfig } from './config.js';
 import { logger } from './logger.js';
-import { DATA_DIR } from './constants.js';
-import { BASE_DATA_DIR } from './constants.js';
+import { BASE_DATA_DIR, DATA_DIR, DEFAULT_WORKING_DIR } from './constants.js';
 import { RUNTIME_OPTIONS } from './runtime.js';
 import { hasAdminInstance, isCurrentInstanceConfigured, listInstances, loadCurrentInstance, saveCurrentInstance, type InstanceConfig } from './instances.js';
 import { GitApprovalStore, type AdminAuditContext } from './governance/approval-store.js';
@@ -273,11 +272,14 @@ async function runDaemon(): Promise<void> {
 
   const api = new WeChatApi(account.botToken, account.baseUrl);
   const approvalStore = new GitApprovalStore(BASE_DATA_DIR);
-  const sessionStore = createSessionStore();
+  const sessionStore = createSessionStore(config.workingDirectory);
   const session: Session = sessionStore.load(account.accountId);
 
-  // Fix: backfill session workingDirectory from config if it's still the default process.cwd()
-  if (config.workingDirectory && session.workingDirectory === process.cwd()) {
+  // Migrate sessions created before per-instance config became the initial session directory.
+  if (
+    config.workingDirectory
+    && (session.workingDirectory === process.cwd() || session.workingDirectory === DEFAULT_WORKING_DIR)
+  ) {
     session.workingDirectory = config.workingDirectory;
     sessionStore.save(account.accountId, session);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { unlinkSync, writeFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 
 import { WeChatApi } from './wechat/api.js';
-import { saveAccount, loadLatestAccount, type AccountData } from './wechat/accounts.js';
+import { loadAccount, loadLatestAccount, type AccountData } from './wechat/accounts.js';
 import { startQrLogin, waitForQrScan } from './wechat/login.js';
 import { createMonitor, type MonitorCallbacks } from './wechat/monitor.js';
 import { createSender } from './wechat/send.js';
@@ -19,6 +19,11 @@ import { filterToolNoise } from './claude/tool-noise-filter.js';
 import { loadConfig, saveConfig } from './config.js';
 import { logger } from './logger.js';
 import { DATA_DIR } from './constants.js';
+import { BASE_DATA_DIR } from './constants.js';
+import { RUNTIME_OPTIONS } from './runtime.js';
+import { hasAdminInstance, isCurrentInstanceConfigured, listInstances, loadCurrentInstance, saveCurrentInstance, type InstanceConfig } from './instances.js';
+import { GitApprovalStore, type AdminAuditContext } from './governance/approval-store.js';
+import { clearSyncBuf } from './wechat/sync-buf.js';
 import { MessageType, type WeixinMessage } from './wechat/types.js';
 import { loadPendingQueue, savePendingQueue, type PendingItem } from './pending-queue.js';
 
@@ -172,10 +177,19 @@ function openFile(filePath: string): void {
 async function runSetup(): Promise<void> {
   mkdirSync(DATA_DIR, { recursive: true });
   const QR_PATH = join(DATA_DIR, 'qrcode.png');
+  const currentInstance = loadCurrentInstance();
+  const role = RUNTIME_OPTIONS.role
+    ?? (isCurrentInstanceConfigured()
+      ? currentInstance.role
+      : (hasAdminInstance(RUNTIME_OPTIONS.instanceId) ? 'requester' : 'admin'));
+  if (role === 'admin' && hasAdminInstance(RUNTIME_OPTIONS.instanceId)) {
+    throw new Error('另一个管理员实例已经存在；每个安装只能配置一个管理员实例');
+  }
 
   console.log('正在设置...\n');
 
   // Loop: generate QR → display → poll for scan → handle expiry → repeat
+  let boundAccount: AccountData | undefined;
   while (true) {
     const { qrcodeUrl, qrcodeId } = await startQrLogin();
 
@@ -211,7 +225,7 @@ async function runSetup(): Promise<void> {
     console.log('等待扫码绑定...');
 
     try {
-      await waitForQrScan(qrcodeId);
+      boundAccount = await waitForQrScan(qrcodeId);
       console.log('✅ 绑定成功!');
       break;
     } catch (err: any) {
@@ -233,7 +247,14 @@ async function runSetup(): Promise<void> {
   config.workingDirectory = workingDir;
   saveConfig(config);
 
-  console.log('运行 npm run daemon -- start 启动服务');
+  const instance = saveCurrentInstance({ role, accountId: boundAccount!.accountId });
+  clearSyncBuf();
+
+  console.log(`实例 ${instance.id} 已配置为 ${instance.role}`);
+  const daemonCommand = process.platform === 'win32'
+    ? `npm run daemon:windows -- start -Instance ${instance.id}`
+    : `npm run daemon -- start --instance ${instance.id}`;
+  console.log(`运行 ${daemonCommand} 启动服务`);
 }
 
 // ---------------------------------------------------------------------------
@@ -242,7 +263,8 @@ async function runSetup(): Promise<void> {
 
 async function runDaemon(): Promise<void> {
   const config = loadConfig();
-  const account = loadLatestAccount();
+  const instance = loadCurrentInstance();
+  const account = (instance.accountId ? loadAccount(instance.accountId) : null) ?? loadLatestAccount();
 
   if (!account) {
     console.error('未找到账号，请先运行 node dist/main.js setup');
@@ -250,6 +272,7 @@ async function runDaemon(): Promise<void> {
   }
 
   const api = new WeChatApi(account.botToken, account.baseUrl);
+  const approvalStore = new GitApprovalStore(BASE_DATA_DIR);
   const sessionStore = createSessionStore();
   const session: Session = sessionStore.load(account.accountId);
 
@@ -279,7 +302,10 @@ async function runDaemon(): Promise<void> {
     processingQueue = true;
     while (messageQueue.length > 0) {
       const msg = messageQueue.shift()!;
-      await handleMessage(msg, account!, session, sessionStore, sender, config, sharedCtx, activeControllers, messageQueue);
+      await handleMessage(
+        msg, account!, instance, approvalStore, session, sessionStore, sender,
+        config, sharedCtx, activeControllers, messageQueue,
+      );
     }
     processingQueue = false;
   }
@@ -330,8 +356,8 @@ async function runDaemon(): Promise<void> {
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
 
-  logger.info('Daemon started', { accountId: account.accountId });
-  console.log(`已启动 (账号: ${account.accountId})`);
+  logger.info('Daemon started', { accountId: account.accountId, instanceId: instance.id, role: instance.role });
+  console.log(`已启动 (实例: ${instance.id}, 角色: ${instance.role}, 账号: ${account.accountId})`);
 
   await monitor.run();
 }
@@ -343,6 +369,8 @@ async function runDaemon(): Promise<void> {
 async function handleMessage(
   msg: WeixinMessage,
   account: AccountData,
+  instance: InstanceConfig,
+  approvalStore: GitApprovalStore,
   session: Session,
   sessionStore: ReturnType<typeof createSessionStore>,
   sender: ReturnType<typeof createSender>,
@@ -384,6 +412,8 @@ async function handleMessage(
 
     const ctx: CommandContext = {
       accountId: account.accountId,
+      instance,
+      approvalStore,
       session,
       updateSession,
       clearSession: () => sessionStore.clear(account.accountId),
@@ -402,6 +432,13 @@ async function handleMessage(
       await sendToClaude(
         result.claudePrompt, imageItem, fileItem, fromUserId, contextToken,
         account, session, sessionStore, sender, config, activeControllers,
+        approvalStore,
+        {
+          instanceId: instance.id,
+          cwdOverride: result.cwdOverride,
+          approvalRequestId: result.approvalRequestId,
+          queryPermission: result.queryPermission ?? (instance.role === 'admin' ? 'admin' : 'read-only'),
+        },
       );
       return;
     }
@@ -426,7 +463,16 @@ async function handleMessage(
   await sendToClaude(
     userText, imageItem, fileItem, fromUserId, contextToken,
     account, session, sessionStore, sender, config, activeControllers,
+    approvalStore,
+    { instanceId: instance.id, queryPermission: instance.role === 'admin' ? 'admin' : 'read-only' },
   );
+}
+
+interface ExecutionOptions {
+  instanceId: string;
+  cwdOverride?: string;
+  approvalRequestId?: string;
+  queryPermission: 'admin' | 'read-only';
 }
 
 function extractTextFromItems(items: NonNullable<WeixinMessage['item_list']>): string {
@@ -490,6 +536,8 @@ async function sendToClaude(
   sender: ReturnType<typeof createSender>,
   config: ReturnType<typeof loadConfig>,
   activeControllers: Map<string, AbortController>,
+  approvalStore: GitApprovalStore,
+  execution: ExecutionOptions,
 ): Promise<void> {
   // Set state to processing
   session.state = 'processing';
@@ -501,14 +549,15 @@ async function sendToClaude(
 
   // Flush timer for streaming text to WeChat during query (declared here for finally cleanup)
   let flushTimer: ReturnType<typeof setInterval> | undefined;
-
-  // Record user message in chat history
-  sessionStore.addChatMessage(session, 'user', userText || '(图片)');
-
-  // Start typing indicator (keepalive until stopTyping is called)
-  const stopTyping = sender.startTyping(fromUserId, contextToken);
+  let stopTyping: () => void = () => {};
+  let approvalFinalized = false;
+  let adminAudit: AdminAuditContext | undefined;
+  let adminAuditFinalized = false;
 
   try {
+    // Record user message in chat history and start the typing keepalive.
+    sessionStore.addChatMessage(session, 'user', userText || '(图片)');
+    stopTyping = sender.startTyping(fromUserId, contextToken);
     // Download image if present
     let images: QueryOptions['images'];
     if (imageItem) {
@@ -609,17 +658,32 @@ async function sendToClaude(
       }
     }, 2000);
 
+    const effectiveCwd = (execution.cwdOverride ?? session.workingDirectory ?? config.workingDirectory).replace(/^~/, homedir());
+    let effectivePermission = execution.queryPermission;
+    let auditMessage = '';
+    if (effectivePermission === 'admin' && !execution.approvalRequestId) {
+      try {
+        adminAudit = approvalStore.prepareAdminAudit(effectiveCwd, execution.instanceId, prompt);
+      } catch (error) {
+        effectivePermission = 'read-only';
+        auditMessage = `管理员写权限已降级为只读: ${error instanceof Error ? error.message : String(error)}`;
+      }
+    }
     const queryOptions: QueryOptions = {
       prompt,
-      cwd: (session.workingDirectory || config.workingDirectory).replace(/^~/, homedir()),
-      resume: session.sdkSessionId,
+      cwd: effectiveCwd,
+      resume: execution.approvalRequestId ? undefined : session.sdkSessionId,
       model: session.model,
       systemPrompt: [
         '你正在通过微信与用户对话，不是在终端里。不要让用户去终端操作。如果用户需要文件，直接输出文件地址就行，会自动识别解析推送文件到用户的微信中。',
         config.systemPrompt,
+        effectivePermission === 'read-only'
+          ? 'You are a read-only requester instance. Inspect and explain, but never modify files, run commands, or claim that changes were applied. Tell the user to submit modifications with /request.'
+          : '',
       ].filter(Boolean).join('\n'),
       abortController,
       images,
+      permission: effectivePermission,
       onText: (delta: string) => {
         router.onText(delta);
       },
@@ -638,6 +702,36 @@ async function sendToClaude(
       sessionStore.save(account.accountId, session);
       const retryResult = await claudeQuery(queryOptions);
       Object.assign(result, retryResult);
+    }
+
+    let approvalMessage = '';
+    if (execution.approvalRequestId) {
+      try {
+        const finalized = approvalStore.finalizeApproval(execution.approvalRequestId, result.error);
+        approvalMessage = finalized.message;
+        approvalFinalized = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        approvalMessage = `Git approval finalization failed: ${message}`;
+        result.error = result.error ? `${result.error}; ${message}` : message;
+      }
+      if (approvalMessage) {
+        result.text = result.text ? `${result.text}\n\nGit 审批结果: ${approvalMessage}` : `Git 审批结果: ${approvalMessage}`;
+      }
+    }
+    if (adminAudit) {
+      try {
+        const audited = approvalStore.finalizeAdminAudit(adminAudit, result.error);
+        if (audited.message) auditMessage = audited.message;
+        adminAuditFinalized = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        auditMessage = `管理员 Git 审计失败: ${message}`;
+        result.error = result.error ? `${result.error}; ${message}` : message;
+      }
+    }
+    if (auditMessage) {
+      result.text = result.text ? `${result.text}\n\nGit 审计: ${auditMessage}` : `Git 审计: ${auditMessage}`;
     }
 
     // Stop periodic flush, drain router (final 先于 interstitial), wait for queued sends
@@ -703,6 +797,14 @@ async function sendToClaude(
       pendingRetry = null;
     }
 
+    // Claude 的流式文本已经发送时，追加的 Git 审批结果不会经过 router，需单独推送。
+    if (approvalMessage && anySent) {
+      await sender.sendText(fromUserId, contextToken, `Git 审批结果: ${approvalMessage}`);
+    }
+    if (auditMessage && anySent) {
+      await sender.sendText(fromUserId, contextToken, `Git 审计: ${auditMessage}`);
+    }
+
     // Send result back to WeChat
     if (result.text) {
       if (result.error) {
@@ -724,13 +826,15 @@ async function sendToClaude(
     }
 
     // Update session with new SDK session ID
-    session.sdkSessionId = result.sessionId || undefined;
+    if (!execution.approvalRequestId) {
+      session.sdkSessionId = result.sessionId || undefined;
+    }
     session.state = 'idle';
     sessionStore.save(account.accountId, session);
 
     // Auto-push deliverable files mentioned in Claude's response
     if (result.text) {
-      const cwd = (session.workingDirectory || config.workingDirectory).replace(/^~/, homedir());
+      const cwd = effectiveCwd;
       const detectedPaths = extractFilePathsFromText(result.text, cwd);
       const { existsSync } = await import('node:fs');
       const { extname } = await import('node:path');
@@ -773,12 +877,34 @@ async function sendToClaude(
       }
     }
   } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    if (execution.approvalRequestId && !approvalFinalized) {
+      try {
+        const finalized = approvalStore.finalizeApproval(execution.approvalRequestId, errorMsg);
+        approvalFinalized = true;
+        await sender.sendText(fromUserId, contextToken, `Git 审批结果: ${finalized.message}`).catch(() => {});
+      } catch (finalizeError) {
+        logger.error('Failed to finalize approval after exception', {
+          requestId: execution.approvalRequestId,
+          error: finalizeError instanceof Error ? finalizeError.message : String(finalizeError),
+        });
+      }
+    }
+    if (adminAudit && !adminAuditFinalized) {
+      try {
+        approvalStore.finalizeAdminAudit(adminAudit, errorMsg);
+        adminAuditFinalized = true;
+      } catch (auditError) {
+        logger.error('Failed to finalize admin Git audit after exception', {
+          error: auditError instanceof Error ? auditError.message : String(auditError),
+        });
+      }
+    }
     const isAbort = err instanceof Error && (err.name === 'AbortError' || err.message.includes('abort'));
     if (isAbort) {
       // Query was cancelled by a new incoming message — exit silently
       logger.info('Claude query aborted by new message');
     } else {
-      const errorMsg = err instanceof Error ? err.message : String(err);
       logger.error('Error in sendToClaude', { error: errorMsg });
       await sender.sendText(fromUserId, contextToken, '处理消息时出错，请稍后重试。');
     }
@@ -798,9 +924,18 @@ async function sendToClaude(
 // CLI
 // ---------------------------------------------------------------------------
 
-const command = process.argv[2];
+const command = RUNTIME_OPTIONS.command;
 
-if (command === 'setup') {
+if (command === 'instances') {
+  const instances = listInstances();
+  if (instances.length === 0) {
+    console.log('尚未配置实例。');
+  } else {
+    for (const instance of instances) {
+      console.log(`${instance.id}\t${instance.role}\t${instance.accountId ?? '未绑定'}`);
+    }
+  }
+} else if (command === 'setup') {
   runSetup().catch((err) => {
     logger.error('Setup failed', { error: err instanceof Error ? err.message : String(err) });
     console.error('设置失败:', err);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,67 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export type InstanceRole = 'admin' | 'requester';
+
+export interface RuntimeOptions {
+  command: string;
+  instanceId: string;
+  role?: InstanceRole;
+}
+
+const INSTANCE_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$/;
+
+export function validateInstanceId(instanceId: string): void {
+  if (!INSTANCE_ID_PATTERN.test(instanceId)) {
+    throw new Error(`Invalid instance id: "${instanceId}"`);
+  }
+}
+
+export function parseRuntimeOptions(args: string[]): RuntimeOptions {
+  let command = 'start';
+  let commandFound = false;
+  let instanceId = process.env.WCC_INSTANCE?.trim() || 'default';
+  let role: InstanceRole | undefined;
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--instance') {
+      instanceId = args[++index]?.trim() || '';
+      continue;
+    }
+    if (arg.startsWith('--instance=')) {
+      instanceId = arg.slice('--instance='.length).trim();
+      continue;
+    }
+    if (arg === '--role') {
+      const value = args[++index]?.trim();
+      if (value !== 'admin' && value !== 'requester') {
+        throw new Error(`Invalid instance role: "${value ?? ''}"`);
+      }
+      role = value;
+      continue;
+    }
+    if (arg.startsWith('--role=')) {
+      const value = arg.slice('--role='.length).trim();
+      if (value !== 'admin' && value !== 'requester') {
+        throw new Error(`Invalid instance role: "${value}"`);
+      }
+      role = value;
+      continue;
+    }
+    if (!arg.startsWith('-') && !commandFound) {
+      command = arg;
+      commandFound = true;
+    }
+  }
+
+  validateInstanceId(instanceId);
+  return { command, instanceId, role };
+}
+
+export const RUNTIME_OPTIONS = parseRuntimeOptions(process.argv.slice(2));
+export const BASE_DATA_DIR = process.env.WCC_DATA_DIR || join(homedir(), '.wechat-claude-code');
+export const INSTANCE_ID = RUNTIME_OPTIONS.instanceId;
+export const INSTANCE_DATA_DIR = INSTANCE_ID === 'default'
+  ? BASE_DATA_DIR
+  : join(BASE_DATA_DIR, 'instances', INSTANCE_ID);

--- a/src/session.ts
+++ b/src/session.ts
@@ -4,8 +4,6 @@ import { DATA_DIR, DEFAULT_WORKING_DIR } from './constants.js';
 import { join } from 'node:path';
 import { logger } from './logger.js';
 
-const SESSIONS_DIR = join(DATA_DIR, 'sessions');
-
 export type SessionState = 'idle' | 'processing';
 
 export interface ChatMessage {
@@ -26,16 +24,21 @@ export interface Session {
 
 const DEFAULT_MAX_HISTORY = 100;
 
-export function createSessionStore() {
+export function createSessionStore(
+  initialWorkingDirectory = DEFAULT_WORKING_DIR,
+  dataDirectory = DATA_DIR,
+) {
+  const sessionsDir = join(dataDirectory, 'sessions');
+
   function getSessionPath(accountId: string): string {
     validateAccountId(accountId);
-    return join(SESSIONS_DIR, `${accountId}.json`);
+    return join(sessionsDir, `${accountId}.json`);
   }
 
   function load(accountId: string): Session {
     validateAccountId(accountId);
     const session = loadJson<Session>(getSessionPath(accountId), {
-      workingDirectory: DEFAULT_WORKING_DIR,
+      workingDirectory: initialWorkingDirectory,
       state: 'idle',
       chatHistory: [],
       maxHistoryLength: DEFAULT_MAX_HISTORY,
@@ -53,7 +56,7 @@ export function createSessionStore() {
   }
 
   function save(accountId: string, session: Session): void {
-    mkdirSync(SESSIONS_DIR, { recursive: true });
+    mkdirSync(sessionsDir, { recursive: true });
 
     // Trim chat history if it exceeds max length before saving
     const maxLen = session.maxHistoryLength || DEFAULT_MAX_HISTORY;
@@ -68,7 +71,7 @@ export function createSessionStore() {
     const session: Session = {
       sdkSessionId: undefined,          // explicitly clear so Object.assign removes it
       previousSdkSessionId: undefined,
-      workingDirectory: currentSession?.workingDirectory ?? DEFAULT_WORKING_DIR,
+      workingDirectory: currentSession?.workingDirectory ?? initialWorkingDirectory,
       model: currentSession?.model,
       state: 'idle',
       chatHistory: [],

--- a/src/tests/approval-store.test.ts
+++ b/src/tests/approval-store.test.ts
@@ -1,0 +1,157 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GitApprovalStore } from '../governance/approval-store.js';
+
+function git(cwd: string, args: string[]): string {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', windowsHide: true });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout || 'git failed');
+  return result.stdout.trim();
+}
+
+function createRepository(root: string): string {
+  const repository = join(root, 'target');
+  git(root, ['init', '-b', 'main', repository]);
+  writeFileSync(join(repository, 'app.txt'), 'before\n', 'utf8');
+  git(repository, ['add', 'app.txt']);
+  git(repository, ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial']);
+  return repository;
+}
+
+test('GitApprovalStore records, executes, commits, and fast-forwards an approved request', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wcc-approval-'));
+  try {
+    const repository = createRepository(root);
+    const store = new GitApprovalStore(join(root, 'data'));
+    const request = store.submit({
+      requesterInstanceId: 'worker-1',
+      requesterAccountId: 'wx-worker',
+      workingDirectory: repository,
+      prompt: 'change app.txt',
+    });
+
+    assert.equal(request.status, 'pending');
+    assert.equal(store.list('pending').length, 1);
+    assert.ok(git(store.ledgerDir, ['log', '-1', '--format=%s']).startsWith('request '));
+
+    const execution = store.prepareApproval(request.id, 'admin');
+    writeFileSync(join(execution.cwd, 'app.txt'), 'after\n', 'utf8');
+    const finalized = store.finalizeApproval(request.id);
+
+    assert.equal(finalized.request.status, 'completed');
+    assert.equal(readFileSync(join(repository, 'app.txt'), 'utf8').replace(/\r\n/g, '\n'), 'after\n');
+    assert.equal(git(repository, ['status', '--porcelain']), '');
+    assert.equal(git(repository, ['rev-parse', 'HEAD']), finalized.request.resultCommit);
+    assert.match(git(repository, ['log', '-1', '--format=%s']), /^wcc: apply request /);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GitApprovalStore refuses approval when target repository is dirty', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wcc-approval-dirty-'));
+  try {
+    const repository = createRepository(root);
+    const store = new GitApprovalStore(join(root, 'data'));
+    const request = store.submit({
+      requesterInstanceId: 'worker-1',
+      requesterAccountId: 'wx-worker',
+      workingDirectory: repository,
+      prompt: 'change app.txt',
+    });
+    writeFileSync(join(repository, 'app.txt'), 'dirty\n', 'utf8');
+    assert.throws(() => store.prepareApproval(request.id, 'admin'), /uncommitted changes/);
+    assert.equal(store.get(request.id).status, 'pending');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GitApprovalStore records rejection in the Git ledger', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wcc-approval-reject-'));
+  try {
+    const repository = createRepository(root);
+    const store = new GitApprovalStore(join(root, 'data'));
+    const request = store.submit({
+      requesterInstanceId: 'worker-1',
+      requesterAccountId: 'wx-worker',
+      workingDirectory: repository,
+      prompt: 'change app.txt',
+    });
+    const rejected = store.reject(request.id, 'admin', 'not needed');
+    assert.equal(rejected.status, 'rejected');
+    assert.equal(rejected.rejectionReason, 'not needed');
+    assert.equal(git(store.ledgerDir, ['log', '-1', '--format=%s']), `reject ${request.id}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GitApprovalStore commits direct admin changes for audit', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wcc-admin-audit-'));
+  try {
+    const repository = createRepository(root);
+    const store = new GitApprovalStore(join(root, 'data'));
+    const context = store.prepareAdminAudit(repository, 'admin', 'update app text');
+    writeFileSync(join(repository, 'app.txt'), 'admin change\n', 'utf8');
+    const result = store.finalizeAdminAudit(context);
+
+    assert.ok(result.commit);
+    assert.match(result.message ?? '', /Git 提交/);
+    assert.equal(git(repository, ['status', '--porcelain']), '');
+    assert.match(git(repository, ['log', '-1', '--format=%s']), /^wcc: admin task by admin/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GitApprovalStore marks a failed approval with no changes', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wcc-approval-failed-'));
+  try {
+    const repository = createRepository(root);
+    const store = new GitApprovalStore(join(root, 'data'));
+    const request = store.submit({
+      requesterInstanceId: 'worker-1',
+      requesterAccountId: 'wx-worker',
+      workingDirectory: repository,
+      prompt: 'change app.txt',
+    });
+    store.prepareApproval(request.id, 'admin');
+    const finalized = store.finalizeApproval(request.id, 'Claude process failed');
+    assert.equal(finalized.request.status, 'failed');
+    assert.match(finalized.message, /failed without file changes/);
+    assert.equal(git(repository, ['log', '-1', '--format=%s']), 'initial');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GitApprovalStore keeps an approved commit on its proposal branch when target moved', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wcc-approval-moved-'));
+  try {
+    const repository = createRepository(root);
+    const store = new GitApprovalStore(join(root, 'data'));
+    const request = store.submit({
+      requesterInstanceId: 'worker-1',
+      requesterAccountId: 'wx-worker',
+      workingDirectory: repository,
+      prompt: 'change app.txt',
+    });
+    const execution = store.prepareApproval(request.id, 'admin');
+    writeFileSync(join(execution.cwd, 'app.txt'), 'proposal\n', 'utf8');
+
+    writeFileSync(join(repository, 'other.txt'), 'concurrent\n', 'utf8');
+    git(repository, ['add', 'other.txt']);
+    git(repository, ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'concurrent']);
+
+    const finalized = store.finalizeApproval(request.id);
+    assert.equal(finalized.request.status, 'ready');
+    assert.equal(readFileSync(join(repository, 'app.txt'), 'utf8').replace(/\r\n/g, '\n'), 'before\n');
+    assert.equal(git(repository, ['rev-parse', finalized.request.proposalBranch!]), finalized.request.resultCommit);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/tests/file-lock.test.ts
+++ b/src/tests/file-lock.test.ts
@@ -1,0 +1,34 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { withFileLock } from '../file-lock.js';
+
+test('file lock records its owner and cleans up after completion', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'wcc-lock-'));
+  const lockPath = join(root, 'nested', 'test.lock');
+  try {
+    const result = withFileLock(lockPath, 'busy', () => {
+      assert.equal(readFileSync(lockPath, 'utf8').trim(), String(process.pid));
+      return 42;
+    });
+    assert.equal(result, 42);
+    assert.throws(() => readFileSync(lockPath, 'utf8'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('file lock recovers a lock owned by a dead process', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'wcc-lock-'));
+  const lockPath = join(root, 'test.lock');
+  try {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(lockPath, '2147483647\n', 'utf8');
+    assert.equal(withFileLock(lockPath, 'busy', () => 'recovered'), 'recovered');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/tests/provider.test.ts
+++ b/src/tests/provider.test.ts
@@ -1,6 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildClaudeArgs, handleStreamLine, type StreamParserState } from '../claude/provider.js';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  buildClaudeArgs,
+  handleStreamLine,
+  resolveClaudeExecutable,
+  type StreamParserState,
+} from '../claude/provider.js';
 
 function freshState(): StreamParserState {
   return { sessionId: '', textParts: [], trackingSkill: false, skillInputAccum: '' };
@@ -122,4 +130,23 @@ test('buildClaudeArgs: requester instance is restricted to read tools and plan m
     '--tools',
     'Read,Grep,Glob',
   ]);
+});
+
+test('resolveClaudeExecutable finds the native executable behind the Windows npm shim', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wcc-claude-bin-'));
+  try {
+    const executable = join(root, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
+    mkdirSync(resolve(executable, '..'), { recursive: true });
+    writeFileSync(executable, '');
+    assert.equal(resolveClaudeExecutable({ PATH: root }, 'win32'), executable);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveClaudeExecutable honors an explicit executable path', () => {
+  assert.equal(
+    resolveClaudeExecutable({ WCC_CLAUDE_PATH: './custom-claude.exe' }, 'win32'),
+    resolve('./custom-claude.exe'),
+  );
 });

--- a/src/tests/provider.test.ts
+++ b/src/tests/provider.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { handleStreamLine, type StreamParserState } from '../claude/provider.js';
+import { buildClaudeArgs, handleStreamLine, type StreamParserState } from '../claude/provider.js';
 
 function freshState(): StreamParserState {
   return { sessionId: '', textParts: [], trackingSkill: false, skillInputAccum: '' };
@@ -102,4 +102,24 @@ test('handleStreamLine: tool_use stop_reason 也正常透传', () => {
     { onTurnEnd: (r) => calls.push(r) },
   );
   assert.deepEqual(calls, ['tool_use']);
+});
+
+test('buildClaudeArgs: admin instance keeps full permission mode', () => {
+  const args = buildClaudeArgs({ permission: 'admin' });
+  assert.ok(args.includes('--dangerously-skip-permissions'));
+  assert.ok(!args.includes('--safe-mode'));
+});
+
+test('buildClaudeArgs: requester instance is restricted to read tools and plan mode', () => {
+  const args = buildClaudeArgs({ permission: 'read-only' });
+  assert.ok(!args.includes('--dangerously-skip-permissions'));
+  assert.ok(args.includes('--safe-mode'));
+  assert.deepEqual(args.slice(args.indexOf('--permission-mode'), args.indexOf('--permission-mode') + 2), [
+    '--permission-mode',
+    'plan',
+  ]);
+  assert.deepEqual(args.slice(args.indexOf('--tools'), args.indexOf('--tools') + 2), [
+    '--tools',
+    'Read,Grep,Glob',
+  ]);
 });

--- a/src/tests/runtime.test.ts
+++ b/src/tests/runtime.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseRuntimeOptions } from '../runtime.js';
+
+test('parseRuntimeOptions parses named requester instance', () => {
+  const options = parseRuntimeOptions(['setup', '--instance', 'wx-work', '--role', 'requester']);
+  assert.deepEqual(options, { command: 'setup', instanceId: 'wx-work', role: 'requester' });
+});
+
+test('parseRuntimeOptions supports equals syntax', () => {
+  const options = parseRuntimeOptions(['start', '--instance=admin.1', '--role=admin']);
+  assert.deepEqual(options, { command: 'start', instanceId: 'admin.1', role: 'admin' });
+});
+
+test('parseRuntimeOptions rejects unsafe instance ids', () => {
+  for (const instanceId of ['../escape', '.', '..', '-leading', 'x'.repeat(65)]) {
+    assert.throws(
+      () => parseRuntimeOptions(['start', '--instance', instanceId]),
+      /Invalid instance id/,
+    );
+  }
+});

--- a/src/tests/session.test.ts
+++ b/src/tests/session.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { createSessionStore } from '../session.js';
+
+test('new sessions inherit the instance working directory', async () => {
+  const dataDirectory = await mkdtemp(join(tmpdir(), 'wcc-session-'));
+  const workingDirectory = join(dataDirectory, 'shared-repo');
+  try {
+    const store = createSessionStore(workingDirectory, dataDirectory);
+    const session = store.load('account@example.com');
+    assert.equal(session.workingDirectory, workingDirectory);
+
+    const cleared = store.clear('account@example.com');
+    assert.equal(cleared.workingDirectory, workingDirectory);
+  } finally {
+    await rm(dataDirectory, { recursive: true, force: true });
+  }
+});

--- a/src/tools/visualize-logs.ts
+++ b/src/tools/visualize-logs.ts
@@ -11,10 +11,8 @@
 
 import { readFileSync, readdirSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { execSync } from 'node:child_process';
-
-const DATA_DIR = process.env.WCC_DATA_DIR || join(homedir(), '.wechat-claude-code');
+import { DATA_DIR } from '../constants.js';
 
 // ─── Keepalive messages (must match main.ts SILENCE_MESSAGES) ───
 const SILENCE_MESSAGES = new Set([

--- a/src/wechat/accounts.ts
+++ b/src/wechat/accounts.ts
@@ -1,8 +1,8 @@
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { readdirSync, statSync } from 'node:fs';
 import { loadJson, saveJson, validateAccountId } from '../store.js';
 import { logger } from '../logger.js';
+import { DATA_DIR } from '../constants.js';
 
 export const DEFAULT_BASE_URL = 'https://ilinkai.weixin.qq.com';
 
@@ -14,7 +14,7 @@ export interface AccountData {
   createdAt: string;
 }
 
-const ACCOUNTS_DIR = join(homedir(), '.wechat-claude-code', 'accounts');
+const ACCOUNTS_DIR = join(DATA_DIR, 'accounts');
 
 function accountPath(accountId: string): string {
   validateAccountId(accountId);

--- a/src/wechat/sync-buf.ts
+++ b/src/wechat/sync-buf.ts
@@ -11,3 +11,7 @@ export function loadSyncBuf(): string {
 export function saveSyncBuf(buf: string): void {
   saveJson(SYNC_BUF_PATH, buf);
 }
+
+export function clearSyncBuf(): void {
+  saveJson(SYNC_BUF_PATH, '');
+}


### PR DESCRIPTION
作者您好，这个 PR 增加了一套可在同一份项目源码上运行多个微信账号实例的工作流，并用 Git 对写入权限进行集中治理。

## 主要改动

- 支持 `--instance <name>` / `WCC_INSTANCE`，每个实例隔离微信凭据、配置、session、同步游标、队列和日志。
- 实例分为唯一 `admin` 与多个 `requester`：
  - `requester` 使用 Claude Code `plan` 权限模式，仅开放 `Read,Grep,Glob`，禁用写文件、Shell、hooks、MCP 和插件。
  - `admin` 保留完整能力，并负责审批所有修改请求。
- 新增 Git 审批命令：`/request`、`/requests`、`/approve`、`/reject`、`/recover`。
- 审批在独立的 `wcc/request/<id>` 分支和 worktree 中执行，自动提交；目标分支未变化时才快进合并，否则保留提案分支供人工处理。
- 管理员直接修改也自动生成 Git 审计提交；非 Git 仓库或工作区已有修改时自动降级为只读。
- 新增 Windows 原生守护脚本 `daemon.ps1`，并让 macOS/Linux 守护脚本支持多实例。
- 增加 PID 锁与崩溃后失效锁恢复。
- 修复实机验证发现的两个 Windows 问题：
  - 新 session 未继承实例配置的工作目录。
  - Node 后台进程无法执行 npm 的 `claude` shim；现在会安全解析原生 `claude.exe`，并支持 `WCC_CLAUDE_PATH` 覆盖，不启用 shell。
- 更新中英文 README 和 SKILL 使用说明。

## 验证

- `npm run build` 通过。
- 39 项自动化测试全部通过。
- PowerShell/Bash 守护脚本解析通过。
- Windows 实机同时绑定并运行一个 admin 和一个 requester 微信账号。
- 使用与微信相同的 `claudeQuery` 调用链实测成功返回结果；第三方 Claude 兼容后端可正常工作。

## 安全边界

这是应用级权限隔离。若所有实例由同一个操作系统用户运行，该用户仍可在程序外修改文件；需要抵抗同用户恶意进程时，仍应使用独立系统用户、容器或虚拟机。